### PR TITLE
update name character validation

### DIFF
--- a/fmcapi/api_objects/policy_services/accessrules.py
+++ b/fmcapi/api_objects/policy_services/accessrules.py
@@ -82,7 +82,7 @@ class AccessRules(APIClassTemplate):
         "BLOCK_INTERACTIVE",
         "BLOCK_RESET_INTERACTIVE",
     ]
-    VALID_CHARACTERS_FOR_NAME = """[.\w\d_\-\<\>\,\ ]"""
+    VALID_CHARACTERS_FOR_NAME = """[.\w\d_\-<>, ]"""
 
     @property
     def URL_SUFFIX(self):

--- a/fmcapi/api_objects/policy_services/accessrules.py
+++ b/fmcapi/api_objects/policy_services/accessrules.py
@@ -82,7 +82,7 @@ class AccessRules(APIClassTemplate):
         "BLOCK_INTERACTIVE",
         "BLOCK_RESET_INTERACTIVE",
     ]
-    VALID_CHARACTERS_FOR_NAME = """[.\w\d_\- ]"""
+    VALID_CHARACTERS_FOR_NAME = """[.\w\d_\-\<\>\,\ ]"""
 
     @property
     def URL_SUFFIX(self):


### PR DESCRIPTION
have tested with FMC 6.6.1, and characters "<", ">", "," are accepted.
example: 
'acp_rule_name': 'SA,HX and DL UCS OOB -> DNS'