### PR TITLE
added support for ICMP objects

### DIFF
--- a/fmcapi/api_objects/policy_services/accessrules.py
+++ b/fmcapi/api_objects/policy_services/accessrules.py
@@ -8,6 +8,7 @@ from fmcapi.api_objects.object_services.securityzones import SecurityZones
 from fmcapi.api_objects.object_services.vlantags import VlanTags
 from fmcapi.api_objects.object_services.portobjectgroups import PortObjectGroups
 from fmcapi.api_objects.object_services.protocolportobjects import ProtocolPortObjects
+from fmcapi.api_objects.object_services.icmpv4objects import ICMPv4Objects
 from fmcapi.api_objects.object_services.fqdns import FQDNS
 from fmcapi.api_objects.object_services.networkgroups import NetworkGroups
 from fmcapi.api_objects.object_services.networkaddresses import NetworkAddresses
@@ -82,7 +83,7 @@ class AccessRules(APIClassTemplate):
         "BLOCK_INTERACTIVE",
         "BLOCK_RESET_INTERACTIVE",
     ]
-    VALID_CHARACTERS_FOR_NAME = """[.\w\d_\-<>, ]"""
+    VALID_CHARACTERS_FOR_NAME = """[.\w\d_\- ]"""
 
     @property
     def URL_SUFFIX(self):
@@ -560,8 +561,12 @@ class AccessRules(APIClassTemplate):
         if action == "add":
             pport_json = ProtocolPortObjects(fmc=self.fmc)
             pport_json.get(name=name)
+            icmpv4_json = ICMPv4Objects(fmc=self.fmc)
+            icmpv4_json.get(name=name)
             if "id" in pport_json.__dict__:
                 item = pport_json
+            elif "id" in icmpv4_json.__dict__:
+                item = icmpv4_json
             else:
                 item = PortObjectGroups(fmc=self.fmc)
                 item.get(name=name)
@@ -629,8 +634,12 @@ class AccessRules(APIClassTemplate):
         elif action == "remove":
             pport_json = ProtocolPortObjects(fmc=self.fmc)
             pport_json.get(name=name)
+            icmpv4_json = ICMPv4Objects(fmc=self.fmc)
+            icmpv4_json.get(name=name)
             if "id" in pport_json.__dict__:
                 item = pport_json
+            elif "id" in icmpv4_json.__dict__:
+                item = icmpv4_json
             else:
                 item = PortObjectGroups(fmc=self.fmc)
                 item.get(name=name)
@@ -670,8 +679,12 @@ class AccessRules(APIClassTemplate):
         if action == "add":
             pport_json = ProtocolPortObjects(fmc=self.fmc)
             pport_json.get(name=name)
+            icmpv4_json = ICMPv4Objects(fmc=self.fmc)
+            icmpv4_json.get(name=name)
             if "id" in pport_json.__dict__:
                 item = pport_json
+            elif "id" in icmpv4_json.__dict__:
+                item = icmpv4_json
             else:
                 item = PortObjectGroups(fmc=self.fmc)
                 item.get(name=name)
@@ -739,8 +752,12 @@ class AccessRules(APIClassTemplate):
         elif action == "remove":
             pport_json = ProtocolPortObjects(fmc=self.fmc)
             pport_json.get(name=name)
+            icmpv4_json = ICMPv4Objects(fmc=self.fmc)
+            icmpv4_json.get(name=name)
             if "id" in pport_json.__dict__:
                 item = pport_json
+            elif "id" in icmpv4_json.__dict__:
+                item = icmpv4_json
             else:
                 item = PortObjectGroups(fmc=self.fmc)
                 item.get(name=name)

--- a/fmcapi/api_objects/policy_services/accessrules.py
+++ b/fmcapi/api_objects/policy_services/accessrules.py
@@ -83,7 +83,7 @@ class AccessRules(APIClassTemplate):
         "BLOCK_INTERACTIVE",
         "BLOCK_RESET_INTERACTIVE",
     ]
-    VALID_CHARACTERS_FOR_NAME = """[.\w\d_\- ]"""
+    VALID_CHARACTERS_FOR_NAME = """[.\w\d_\-<>, ]"""
 
     @property
     def URL_SUFFIX(self):


### PR DESCRIPTION
In addition to port objects and port groups, I've included support for ICMPv4 object in ACP rules. 
For now I needed only ICMPv4, but for other protocols (ICMPv6, IKE, etc) can be probably added in the same way. 