### PR TITLE
Bulk delete for access rules

### DIFF
--- a/fmcapi/api_objects/policy_services/accessrules.py
+++ b/fmcapi/api_objects/policy_services/accessrules.py
@@ -26,6 +26,7 @@ from fmcapi.api_objects.object_services.realmusergroups import RealmUserGroups
 from fmcapi.api_objects.object_services.realmusers import RealmUsers
 import logging
 import sys
+import json
 
 
 class AccessRules(APIClassTemplate):
@@ -1578,5 +1579,27 @@ class Bulk(object):
                     f"This chunk of the post is too large.  Please submit less items to be bulk posted."
                 )
             response = self.fmc.send_to_api(method="post", url=self.URL, json_data=item)
-            logging.info(f"Posting to bulk items.")
+            logging.info(f"Posting bulk items.")
             return response
+
+    def delete(self):
+        """
+        Delete list of self.items in FMC as a bulk operation.
+
+        :return: (str) requests response from FMC
+        """
+
+        # Prepare rule ids
+        ids = []
+        for item in self.items:
+            obj = json.loads(item)
+            ids.append(obj["id"])
+
+        # Build URL
+        filter = "ids:"+",".join(ids)
+        self.URL = f"{self.URL}{self.URL_SUFFIX}&bulk=true&filter={filter}"
+
+        response = self.fmc.send_to_api(method="delete", url=self.URL, json_data=self.items)
+        logging.info(f"Deleting bulk items.")
+        return response
+

--- a/fmcapi/api_objects/policy_services/accessrules.py
+++ b/fmcapi/api_objects/policy_services/accessrules.py
@@ -26,7 +26,6 @@ from fmcapi.api_objects.object_services.realmusergroups import RealmUserGroups
 from fmcapi.api_objects.object_services.realmusers import RealmUsers
 import logging
 import sys
-import json
 
 
 class AccessRules(APIClassTemplate):
@@ -1592,8 +1591,7 @@ class Bulk(object):
         # Prepare rule ids
         ids = []
         for item in self.items:
-            obj = json.loads(item)
-            ids.append(obj["id"])
+            ids.append(item.id)
 
         # Build URL
         filter = "ids:"+",".join(ids)


### PR DESCRIPTION
**New:**
- method for bulk deleting many access rules in one bulk request.  List of rules is derived from existing bulk class.

**Example:**
```
acpId = "<some guid>"
accessRule1 = AccessRules(fmc=fmc, acp_id=acpId)
accessRule2 = AccessRules(fmc=fmc, acp_id=acpId)

bulkPost = Bulk(fmc=fmc,url=(accessRule1.URL + "?")) 
bulkPost.add(accessRule1.show_json)
bulkPost.add(accessRule2.show_json)
bulkPost.delete()
```

**Note:**
Bulk class needs more work as explained in last post [of this issue](https://github.com/marksull/fmcapi/issues/63) . This change is just adding new method for bulk deleting.