### PR TITLE
Feature/access rules bulk post use object

### DIFF
--- a/example/mixed_logic_and_data/hq-ftd.py
+++ b/example/mixed_logic_and_data/hq-ftd.py
@@ -159,7 +159,9 @@ def main():
 
         bulk.post()
 
-        # Bulk create example
+        bulk.clear()
+
+        # Bulk delete example
         bulk = Bulk(fmc=fmc1)
         for r in range(1, 10):
             # Use acp_id instead of acp_name to avoid fmcapi looking up the acp

--- a/example/mixed_logic_and_data/hq-ftd.py
+++ b/example/mixed_logic_and_data/hq-ftd.py
@@ -4,6 +4,8 @@ Configure FMC for hq-ftd, register hq-ftd and push changes to it.
 
 import fmcapi  # You can use 'from fmcapi import *' but it is best practices to keep the namespaces separate.
 
+from fmcapi.api_objects.policy_services.accessrules import Bulk
+
 
 def main():
     """
@@ -143,6 +145,33 @@ def main():
         assign_nat_policy = fmcapi.PolicyAssignments(fmc=fmc1)
         assign_nat_policy.ftd_natpolicy(name=nat.name, devices=devices)
         assign_nat_policy.post()
+
+        # Bulk create example
+        bulk = Bulk(fmc=fmc1)
+        for r in range(1, 10):
+            # Use acp_id instead of acp_name to avoid fmcapi looking up the acp
+            # id for each rule
+            rule = fmcapi.AccessRules(fmc=fmc1, acp_id=acp.id)
+            rule.action = "ALLOW"
+            rule.name = f"rule-{r}"
+            rule.enabled = True
+            bulk.add(rule)
+
+        bulk.post()
+
+        # Bulk create example
+        bulk = Bulk(fmc=fmc1)
+        for r in range(1, 10):
+            # Use acp_id instead of acp_name to avoid fmcapi looking up the acp
+            # id for each rule
+            rule = fmcapi.AccessRules(fmc=fmc1, acp_id=acp.id)
+            rule.name = f"rule-{r}"
+            # You must perform a get on the rule so that fmcapi loads the ID
+            # for the rule which is required for the deletion
+            rule.get()
+            bulk.add(rule)
+
+        bulk.delete()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Update the AccessRules Bulk class to:
- use non-serialised AccessRule objects in the item list
- Correctly cater for both the number of rules allowed per payload and the max payload size
- Automatically determine the bulk update URL from the first rule in the list

@dalamanster, the update as promised. Note I have made a few small enhancements such a fixing the paging of the bulk updates and there is no longer a need to provide the URL to the Bulk class. Examples:

```
        # Bulk create example
        bulk = Bulk(fmc=fmc1)
        for r in range(1, 10):
            # Use acp_id instead of acp_name to avoid fmcapi looking up the acp
            # id for each rule
            rule = fmcapi.AccessRules(fmc=fmc1, acp_id=acp.id)
            rule.action = "ALLOW"
            rule.name = f"rule-{r}"
            rule.enabled = True
            bulk.add(rule)

        bulk.post()

        # Bulk delete example
        bulk = Bulk(fmc=fmc1)
        for r in range(1, 10):
            # Use acp_id instead of acp_name to avoid fmcapi looking up the acp
            # id for each rule
            rule = fmcapi.AccessRules(fmc=fmc1, acp_id=acp.id)
            rule.name = f"rule-{r}"
            # You must perform a get on the rule so that fmcapi loads the ID
            # for the rule which is required for the deletion
            rule.get()
            bulk.add(rule)

        bulk.delete()
```

