### PR TITLE
Support for backup api endpoint

### DIFF
--- a/TestingUserScript.py
+++ b/TestingUserScript.py
@@ -77,6 +77,7 @@ def main():
         unit_tests.test__ports(fmc=fmc1)
         unit_tests.test__autonat(fmc=fmc1)
         unit_tests.test__manualnat(fmc=fmc1)
+        unit_tests.test__backup(fmc=fmc1) # Delete needs existing backup and may need an increased fmc timeout for large backups
         """
 
         """

--- a/fmcapi/api_objects/__init__.py
+++ b/fmcapi/api_objects/__init__.py
@@ -111,6 +111,7 @@ from .update_packages.upgradepackages import UpgradePackages
 from .update_packages.upgradepackage import Upgrades
 
 from .policy_services.loggingsettings import LoggingSettings
+from .backup_services.backup import Backup
 
 logging.debug("In the api_objects __init__.py file.")
 
@@ -208,4 +209,5 @@ __all__ = [
     "UpgradePackages",
     "Upgrades",
     "LoggingSettings",
+    "Backup"
 ]

--- a/fmcapi/api_objects/apiclasstemplate.py
+++ b/fmcapi/api_objects/apiclasstemplate.py
@@ -124,8 +124,13 @@ class APIClassTemplate(object):
             )
             return {"items": []}
         if self.valid_for_get():
-            if "id" in self.__dict__:
-                url = f"{self.URL}/{self.id}"
+            if "id" in self.__dict__ or "targetId" in self.__dict__:
+                if "targetId" in self.__dict__:
+                    url = f"{self.URL}/{self.targetId}"
+                    if "backupVersion" in self.__dict__:
+                        url += f"?backupVersion={self.backupVersion}"
+                else:
+                    url = f"{self.URL}/{self.id}"
                 if self.dry_run:
                     logging.info(
                         "Dry Run enabled.  Not actually sending to FMC.  Here is what would have been sent:"
@@ -144,6 +149,15 @@ class APIClassTemplate(object):
                 if "name" in self.__dict__:
                     logging.info(
                         f'GET success. Object with name: "{self.name}" and id: "{self.id}" fetched from FMC.'
+                    )
+                elif "targetId" in self.__dict__:
+                    if "backupVersion" in self.__dict__:
+                        logging.info(
+                            f'GET success. Object with targetId: "{self.targetId}"\
+                                backupVersion: "{self.backupVersion}" fetched from FMC.'
+                        )
+                    logging.info(
+                        f'GET success. Object with targetId: "{self.targetId}" fetched from FMC.'
                     )
                 else:
                     logging.info(
@@ -351,7 +365,12 @@ class APIClassTemplate(object):
             )
             return False
         if self.valid_for_delete():
-            url = f"{self.URL}/{self.id}"
+            if "targetId" in self.__dict__:
+                url = f"{self.URL}/{self.targetId}"
+                if "backupVersion" in self.__dict__:
+                    url += f"?backupVersion={self.backupVersion}"
+            else:
+                url = f"{self.URL}/{self.id}"
             if self.dry_run:
                 logging.info(
                     "Dry Run enabled.  Not actually sending to FMC.  Here is what would have been sent:"
@@ -370,6 +389,16 @@ class APIClassTemplate(object):
                 logging.info(
                     f'DELETE success. Object with name: "{self.name}" and id: "{self.id}" deleted in FMC.'
                 )
+            elif "targetId" in self.__dict__:
+                if "backupVersion" in self.__dict__:
+                    logging.info(
+                        f'DELETE success. Object with targetId: "{self.targetId}"\
+                            backupVersion: "{self.backupVersion}" deleted from FMC.'
+                    )
+                else:
+                    logging.info(
+                        f'DELETE success. Object with targetId: "{self.targetId}" deleted from FMC.'
+                    )
             else:
                 logging.info(f'DELETE success. Object id: "{self.id}" deleted in FMC.')
             return response

--- a/fmcapi/api_objects/backup_services/__init__.py
+++ b/fmcapi/api_objects/backup_services/__init__.py
@@ -1,0 +1,8 @@
+"""Backup Services Classes."""
+
+import logging
+from .backup import Backup
+
+logging.debug("In the backup_services __init__.py file.")
+
+__all__ = ["Backup"]

--- a/fmcapi/api_objects/backup_services/backup.py
+++ b/fmcapi/api_objects/backup_services/backup.py
@@ -1,0 +1,72 @@
+from fmcapi.api_objects.apiclasstemplate import APIClassTemplate
+import logging
+
+
+class Backup(APIClassTemplate):
+    """The Backup Object in the FMC."""
+    FIRST_SUPPORTED_FMC_VERSION = "7.3"
+    VALID_JSON_DATA = []
+    VALID_FOR_KWARGS = VALID_JSON_DATA + [
+        "targetId",
+        "backupVersion",
+    ]
+    REQUIRED_FOR_DELETE = [
+        "targetId",
+        "backupVersion",
+    ]
+
+    URL_SUFFIX = "/backup/files"
+
+    def __init__(self, fmc, **kwargs):
+        """
+        Initialize Backup object.
+
+        :param fmc (object): FMC object
+        :param **kwargs: Any other values passed during instantiation.
+        :return: requests response
+        """
+        super().__init__(fmc, **kwargs)
+        logging.debug("In __init__() for Backup class.")
+        self.parse_kwargs(**kwargs)
+
+    def get(self, **kwargs):
+        """
+        Prepare to send GET call to FMC Backup Files API.
+
+        If no self.targetId exists then return a full listing of all
+        backups. Self.targetId must be set to 'manager' to target an FMC backup, otherwise,
+        set self.targetId to device UUID to target backups for a particular FTD device.
+        Set self.backupVersion(optional) with self.targetId to a specific backup version ID
+        otherwise the latest backup version of self.targetId will be used.
+        Set "expanded=true" results for specific object
+        to gather additional detail.
+
+        :return: requests response
+        """
+        super().get(**kwargs)
+
+    def delete(self, **kwargs):
+        """
+        Prepare to send DELETE call to FMC Backup Files API.
+
+        Self.targetId is required.
+        Set self.targetId must be set to 'manager' to target an FMC backup, otherwise,
+        set self.targetId to device UUID to target backups for a particular FTD device.
+        Set self.backupVersion is technically optional, but is being enforced as required for extra safety.
+        Otherwise, the latest backup could be deleted unintentionally.
+        Set "expanded=true" results for specific object
+        to gather additional detail.
+
+        :return: requests response
+        """
+        super().delete(**kwargs)
+
+    def post(self):
+        """POST method for API for Backup not supported."""
+        logging.info("POST method for API for Backup not supported.")
+        pass
+
+    def put(self):
+        """PUT method for API for Backup not supported."""
+        logging.info("PUT method for API for Backup not supported.")
+        pass

--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -67,6 +67,7 @@ from .s2s_vpn import test__ftds2svpns
 from .search_globalsearch import test__globalsearch
 from .search_object import test__object
 from .search_policy import test__policy
+from .backup import test__backup
 
 logging.debug("In the unit-tests __init__.py file.")
 
@@ -138,4 +139,5 @@ __all__ = [
     "test__globalsearch",
     "test__object",
     "test__policy",
+    "test__backup",
 ]

--- a/unit_tests/backup.py
+++ b/unit_tests/backup.py
@@ -1,0 +1,18 @@
+import logging
+import fmcapi
+
+
+def test__backup(fmc):
+    logging.info("Test Backup.  Get, delete Backups.")
+
+    obj1 = fmcapi.Backup(fmc=fmc)
+    obj1.get()
+    del(obj1)
+
+    # Requires existing backup and there does not seem to be a way to initiate an FMC backup from the API
+    # There is a way to initiate a device backup with /backup/operational/devicebackup
+
+    # obj1 = fmcapi.Backup(fmc=fmc)
+    # obj1.delete(targetId='manager', backupVersion=1694394505)
+
+    logging.info("Test Backup done.\n")


### PR DESCRIPTION
We needed a way to clean up backups on remote storage on a schedule since FMC doesn't natively seem to have a backup retention policy. This should be enough to get us where we wanted and still use fmcapi lib. 