### PR TITLE
Description added to objects & Remove port from required protocolport…

### DIFF
--- a/fmcapi/api_objects/object_services/fqdns.py
+++ b/fmcapi/api_objects/object_services/fqdns.py
@@ -10,6 +10,7 @@ class FQDNS(APIClassTemplate):
     VALID_JSON_DATA = [
         "id",
         "name",
+        'description',
         "type",
         "overridableTargetId",
         "value",

--- a/fmcapi/api_objects/object_services/icmpv4objects.py
+++ b/fmcapi/api_objects/object_services/icmpv4objects.py
@@ -10,6 +10,7 @@ class ICMPv4Objects(APIClassTemplate):
     VALID_JSON_DATA = [
         "id",
         "name",
+        "description",
         "type",
         "overrideTargetId",
         "code",

--- a/fmcapi/api_objects/object_services/protocolportobjects.py
+++ b/fmcapi/api_objects/object_services/protocolportobjects.py
@@ -10,7 +10,7 @@ class ProtocolPortObjects(APIClassTemplate):
     VALID_JSON_DATA = ["id", "name", "description", "port", "protocol", "type"]
     VALID_FOR_KWARGS = VALID_JSON_DATA + []
     URL_SUFFIX = "/object/protocolportobjects"
-    REQUIRED_FOR_POST = ["name", "port", "protocol"]
+    REQUIRED_FOR_POST = ["name",  "protocol"]
 
     def __init__(self, fmc, **kwargs):
         """


### PR DESCRIPTION
By removing port from required_for_post for protocolportobject allows creation of  non tcp/udp objects (poor naming by cisco api?) 
Added descriptions to valid json data for common problematic objects (requested by more than one of my clients)