### PR TITLE
Support for find usage endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ venv/*
 .mypy_cache/
 .idea/workspace.xml
 tests/
+
+# Mac's finder files
+.DS_Store

--- a/TestingUserScript.py
+++ b/TestingUserScript.py
@@ -79,6 +79,7 @@ def main():
         unit_tests.test__manualnat(fmc=fmc1)
         unit_tests.test__backup(fmc=fmc1) # Delete needs existing backup and may need an increased fmc timeout for large backups
         unit_tests.test__objects_get_query_filters(fmc=fmc1)
+        unit_tests.test__usage(fmc=fmc1)
         """
 
         """

--- a/TestingUserScript.py
+++ b/TestingUserScript.py
@@ -78,6 +78,7 @@ def main():
         unit_tests.test__autonat(fmc=fmc1)
         unit_tests.test__manualnat(fmc=fmc1)
         unit_tests.test__backup(fmc=fmc1) # Delete needs existing backup and may need an increased fmc timeout for large backups
+        unit_tests.test__objects_get_query_filters(fmc=fmc1)
         """
 
         """

--- a/fmcapi/api_objects/__init__.py
+++ b/fmcapi/api_objects/__init__.py
@@ -112,6 +112,7 @@ from .update_packages.upgradepackage import Upgrades
 
 from .policy_services.loggingsettings import LoggingSettings
 from .backup_services.backup import Backup
+from .object_services.usage import Usage
 
 logging.debug("In the api_objects __init__.py file.")
 
@@ -209,5 +210,6 @@ __all__ = [
     "UpgradePackages",
     "Upgrades",
     "LoggingSettings",
-    "Backup"
+    "Backup",
+    "Usage",
 ]

--- a/fmcapi/api_objects/apiclasstemplate.py
+++ b/fmcapi/api_objects/apiclasstemplate.py
@@ -13,6 +13,7 @@ class APIClassTemplate(object):
     REQUIRED_FOR_PUT = ["id"]
     REQUIRED_FOR_DELETE = ["id"]
     REQUIRED_FOR_GET = [""]
+    REQUIRED_GET_FILTERS = []
     FILTER_BY_NAME = False
     URL = ""
     URL_SUFFIX = ""
@@ -104,6 +105,11 @@ class APIClassTemplate(object):
         :return: (boolean)
         """
         logging.debug("In valid_for_get() for APIClassTemplate class.")
+        if len(self.REQUIRED_GET_FILTERS) > 0:
+            for item in self.REQUIRED_GET_FILTERS:
+                if item not in self.get_filters:
+                    logging.error(f'Missing REQUIRED_GET_FILTERS "{item}" for GET request.')
+                    return False
         if self.REQUIRED_FOR_GET == [""]:
             return True
         for item in self.REQUIRED_FOR_GET:

--- a/fmcapi/api_objects/apiclasstemplate.py
+++ b/fmcapi/api_objects/apiclasstemplate.py
@@ -153,8 +153,7 @@ class APIClassTemplate(object):
                 elif "targetId" in self.__dict__:
                     if "backupVersion" in self.__dict__:
                         logging.info(
-                            f'GET success. Object with targetId: "{self.targetId}"\
-                                backupVersion: "{self.backupVersion}" fetched from FMC.'
+                            f'GET success. Object with targetId: "{self.targetId}" backupVersion: "{self.backupVersion}" fetched from FMC.'
                         )
                     logging.info(
                         f'GET success. Object with targetId: "{self.targetId}" fetched from FMC.'
@@ -392,8 +391,7 @@ class APIClassTemplate(object):
             elif "targetId" in self.__dict__:
                 if "backupVersion" in self.__dict__:
                     logging.info(
-                        f'DELETE success. Object with targetId: "{self.targetId}"\
-                            backupVersion: "{self.backupVersion}" deleted from FMC.'
+                        f'DELETE success. Object with targetId: "{self.targetId}" backupVersion: "{self.backupVersion}" deleted from FMC.'
                     )
                 else:
                     logging.info(

--- a/fmcapi/api_objects/apiclasstemplate.py
+++ b/fmcapi/api_objects/apiclasstemplate.py
@@ -19,6 +19,7 @@ class APIClassTemplate(object):
     VALID_CHARACTERS_FOR_NAME = """[.\w\d_\-]"""
     FIRST_SUPPORTED_FMC_VERSION = "6.1"
     VALID_JSON_DATA = []
+    VALID_GET_FILTERS = []
     GLOBAL_VALID_FOR_KWARGS = ["dry_run"]
     VALID_FOR_KWARGS = VALID_JSON_DATA + []
 
@@ -46,6 +47,8 @@ class APIClassTemplate(object):
         self.description = "Created by fmcapi."
         self.overridable = False
         self.dry_run = False
+        self.expanded = False
+        self.get_filters = {}
         self.URL = f"{self.fmc.configuration_url}{self.URL_SUFFIX}"
         if self.fmc.serverVersion < self.FIRST_SUPPORTED_FMC_VERSION:
             logging.warning(
@@ -81,7 +84,10 @@ class APIClassTemplate(object):
         logging.debug("In parse_kwargs() for APIClassTemplate class.")
         for key_value in self.VALID_FOR_KWARGS:
             if key_value in kwargs:
-                self.__dict__[key_value] = kwargs[key_value]
+                if key_value in self.VALID_GET_FILTERS:
+                    self.get_filters[key_value] = kwargs[key_value]
+                else:
+                    self.__dict__[key_value] = kwargs[key_value]
         if "name" in kwargs:
             self.name = syntax_correcter(
                 kwargs["name"], permitted_syntax=self.VALID_CHARACTERS_FOR_NAME
@@ -112,8 +118,13 @@ class APIClassTemplate(object):
 
         If no self.name or self.id exists then return a full listing of all
         objects of this type otherwise return requested name/id values.  Set "expanded=true" results for specific object
-        to gather additional detail.
+        to gather additional detail. Set "unusedOnly=True" to query for unused objects only for certain object types. Set
+        "nameOrValue=String" to filter for a particular name or value of an object. This includes partial matches and is 
+        available for some objects.
 
+        :param: expanded=Bool
+        :param: unusedOnly=Bool
+        :param: nameOrValue=String
         :return: requests response
         """
         logging.debug("In get() for APIClassTemplate class.")
@@ -193,6 +204,36 @@ class APIClassTemplate(object):
                     logging.debug(
                         f"\tGET query for {self.name} is not found.\n\t\tResponse: {json.dumps(response)}"
                     )
+            elif len(self.get_filters) > 0:
+                url_filter = ''
+                for key,value in self.get_filters.items():
+                    #Filter value must not be empty otherwise will result in a 400 response
+                    if value != '':
+                        url_filter += f'{key}%3A{value};'
+                    else:
+                        logging.warning(f'Terminating GET - {self.URL}?expanded={self.expanded}&filter={url_filter}')
+                        logging.warning(f'{key} MUST have a non empty value')
+                        return False
+                url = f"{self.URL}?expanded={self.expanded}&filter={url_filter}"
+                if self.dry_run:
+                    logging.info(
+                        "Dry Run enabled.  Not actually sending to FMC.  Here is what would have been sent:"
+                    )
+                    logging.info("\tMethod = GET")
+                    logging.info(f"\tURL = {url}")
+                    return False
+                response = self.fmc.send_to_api(method="get", url=url)
+                if "items" not in response:
+                    logging.info(
+                        f'GET success. No Objects were found with query filter: {self.get_filters}'
+                    )
+                    return response
+                else:
+                    response_count = response.get("paging").get("count")
+                    logging.info(
+                        f'GET success. {response_count} items found that match query filter: {self.get_filters}'
+                    )
+                    return response
             else:
                 logging.debug(
                     "GET query for object with no name or id set.  "

--- a/fmcapi/api_objects/object_services/__init__.py
+++ b/fmcapi/api_objects/object_services/__init__.py
@@ -46,6 +46,7 @@ from .tunneltags import TunnelTags
 from .urls import URLs
 from .urlcategories import URLCategories
 from .urlgroups import URLGroups
+from .usage import Usage
 from .variablesets import VariableSets
 from .vlangrouptags import VlanGroupTags
 from .vlantags import VlanTags
@@ -98,6 +99,7 @@ __all__ = [
     "URLCategories",
     "URLGroups",
     "URLs",
+    "Usage",
     "VariableSets",
     "VlanGroupTags",
     "VlanTags",

--- a/fmcapi/api_objects/object_services/anyprotocolportobjects.py
+++ b/fmcapi/api_objects/object_services/anyprotocolportobjects.py
@@ -8,7 +8,8 @@ class AnyProtocolPortObjects(APIClassTemplate):
     """The AnyProtocolPortObjects Object in the FMC."""
 
     VALID_JSON_DATA = ["id", "name", "type", "overrideTargetId"]
-    VALID_FOR_KWARGS = VALID_JSON_DATA + []
+    VALID_GET_FILTERS = ["unusedOnly", "nameOrValue"] #unusedOnly:Bool, nameOrValue:String
+    VALID_FOR_KWARGS = VALID_JSON_DATA + VALID_GET_FILTERS + []
     URL_SUFFIX = "/object/anyprotocolportobjects"
 
     def __init__(self, fmc, **kwargs):

--- a/fmcapi/api_objects/object_services/fqdns.py
+++ b/fmcapi/api_objects/object_services/fqdns.py
@@ -17,7 +17,8 @@ class FQDNS(APIClassTemplate):
         "overrides",
         "overridable",
     ]
-    VALID_FOR_KWARGS = VALID_JSON_DATA + []
+    VALID_GET_FILTERS = ["unusedOnly", "nameOrValue"] #unusedOnly:Bool, nameOrValue:String
+    VALID_FOR_KWARGS = VALID_JSON_DATA + VALID_GET_FILTERS + []
     URL_SUFFIX = "/object/fqdns"
     VALID_FOR_DNS_RESOLUTION = ["IPV4_ONLY", "IPV6_ONLY", "IPV4_AND_IPV6"]
     VALID_CHARACTERS_FOR_NAME = """[.\w\d_\- ]"""

--- a/fmcapi/api_objects/object_services/hosts.py
+++ b/fmcapi/api_objects/object_services/hosts.py
@@ -9,7 +9,8 @@ class Hosts(APIClassTemplate):
     """The Host Object in the FMC."""
 
     VALID_JSON_DATA = ["id", "name", "type", "value", "description"]
-    VALID_FOR_KWARGS = VALID_JSON_DATA + []
+    VALID_GET_FILTERS = ["unusedOnly", "nameOrValue"] #unusedOnly:Bool, nameOrValue:String
+    VALID_FOR_KWARGS = VALID_JSON_DATA + VALID_GET_FILTERS + []
     URL_SUFFIX = "/object/hosts"
     REQUIRED_FOR_POST = ["name", "value"]
     REQUIRED_FOR_PUT = ["id", "name", "value"]

--- a/fmcapi/api_objects/object_services/icmpv4objects.py
+++ b/fmcapi/api_objects/object_services/icmpv4objects.py
@@ -17,7 +17,8 @@ class ICMPv4Objects(APIClassTemplate):
         "overrides",
         "overridable",
     ]
-    VALID_FOR_KWARGS = VALID_JSON_DATA + []
+    VALID_GET_FILTERS = ["unusedOnly", "nameOrValue"] #unusedOnly:Bool, nameOrValue:String
+    VALID_FOR_KWARGS = VALID_JSON_DATA + VALID_GET_FILTERS + []
     URL_SUFFIX = "/object/icmpv4objects"
     VALID_CHARACTERS_FOR_NAME = """[.\w\d_\- ]"""
 

--- a/fmcapi/api_objects/object_services/icmpv6objects.py
+++ b/fmcapi/api_objects/object_services/icmpv6objects.py
@@ -17,7 +17,8 @@ class ICMPv6Objects(APIClassTemplate):
         "overrides",
         "overridable",
     ]
-    VALID_FOR_KWARGS = VALID_JSON_DATA + []
+    VALID_GET_FILTERS = ["unusedOnly", "nameOrValue"] #unusedOnly:Bool, nameOrValue:String
+    VALID_FOR_KWARGS = VALID_JSON_DATA + VALID_GET_FILTERS + []
     URL_SUFFIX = "/object/icmpv6objects"
     VALID_CHARACTERS_FOR_NAME = """[.\w\d_\- ]"""
 

--- a/fmcapi/api_objects/object_services/networkaddresses.py
+++ b/fmcapi/api_objects/object_services/networkaddresses.py
@@ -7,6 +7,9 @@ import logging
 class NetworkAddresses(APIClassTemplate):
     """The NetworkAddresses Object in the FMC."""
 
+    VALID_JSON_DATA = []
+    VALID_GET_FILTERS = ["unusedOnly", "nameOrValue", "type", "includeWildcard"] #unusedOnly:Bool, nameOrValue:String, type:String CSV [FQDN,RANGE,HOST,NETWORK], includeWildcard:Bool
+    VALID_FOR_KWARGS = VALID_JSON_DATA + VALID_GET_FILTERS + []
     URL_SUFFIX = "/object/networkaddresses"
 
     def __init__(self, fmc, **kwargs):

--- a/fmcapi/api_objects/object_services/networkgroups.py
+++ b/fmcapi/api_objects/object_services/networkgroups.py
@@ -10,7 +10,8 @@ class NetworkGroups(APIClassTemplate):
     """The NetworkGroups Object in the FMC."""
 
     VALID_JSON_DATA = ["id", "name", "type", "objects", "literals", "description"]
-    VALID_FOR_KWARGS = VALID_JSON_DATA + []
+    VALID_GET_FILTERS = ["unusedOnly", "nameOrValue"] #unusedOnly:Bool, nameOrValue:String
+    VALID_FOR_KWARGS = VALID_JSON_DATA + VALID_GET_FILTERS + []
     URL_SUFFIX = "/object/networkgroups"
 
     # Technically you can have objects OR literals but I'm not set up for "OR" logic, yet.

--- a/fmcapi/api_objects/object_services/networks.py
+++ b/fmcapi/api_objects/object_services/networks.py
@@ -9,7 +9,8 @@ class Networks(APIClassTemplate):
     """The Networks Object in the FMC."""
 
     VALID_JSON_DATA = ["id", "name", "value", "description"]
-    VALID_FOR_KWARGS = VALID_JSON_DATA + []
+    VALID_GET_FILTERS = ["unusedOnly", "nameOrValue"] #unusedOnly:Bool, nameOrValue:String
+    VALID_FOR_KWARGS = VALID_JSON_DATA + VALID_GET_FILTERS + []
     URL_SUFFIX = "/object/networks"
     REQUIRED_FOR_POST = ["name", "value"]
 

--- a/fmcapi/api_objects/object_services/portobjectgroups.py
+++ b/fmcapi/api_objects/object_services/portobjectgroups.py
@@ -9,7 +9,8 @@ class PortObjectGroups(APIClassTemplate):
     """The PortObjectGroups Object in the FMC."""
 
     VALID_JSON_DATA = ["id", "name", "type", "objects", "literals", "description"]
-    VALID_FOR_KWARGS = VALID_JSON_DATA + []
+    VALID_GET_FILTERS = ["unusedOnly", "nameOrValue"] #unusedOnly:Bool, nameOrValue:String
+    VALID_FOR_KWARGS = VALID_JSON_DATA + VALID_GET_FILTERS + []
     URL_SUFFIX = "/object/portobjectgroups"
 
     # Technically you can have objects OR literals but I'm not set up for "OR" logic, yet.

--- a/fmcapi/api_objects/object_services/ports.py
+++ b/fmcapi/api_objects/object_services/ports.py
@@ -7,6 +7,9 @@ import logging
 class Ports(APIClassTemplate):
     """The Ports Object in the FMC."""
 
+    VALID_JSON_DATA = ["id"]
+    VALID_GET_FILTERS = ["unusedOnly", "nameOrValue"] #unusedOnly:Bool, nameOrValue:String
+    VALID_FOR_KWARGS = VALID_JSON_DATA + VALID_GET_FILTERS + []
     URL_SUFFIX = "/object/ports"
 
     def __init__(self, fmc, **kwargs):

--- a/fmcapi/api_objects/object_services/protocolportobjects.py
+++ b/fmcapi/api_objects/object_services/protocolportobjects.py
@@ -8,7 +8,8 @@ class ProtocolPortObjects(APIClassTemplate):
     """The ProtocolPortObjects in the FMC."""
 
     VALID_JSON_DATA = ["id", "name", "description", "port", "protocol", "type"]
-    VALID_FOR_KWARGS = VALID_JSON_DATA + []
+    VALID_GET_FILTERS = ["unusedOnly", "nameOrValue"] #unusedOnly:Bool, nameOrValue:String
+    VALID_FOR_KWARGS = VALID_JSON_DATA + VALID_GET_FILTERS + []
     URL_SUFFIX = "/object/protocolportobjects"
     REQUIRED_FOR_POST = ["name", "port", "protocol"]
 

--- a/fmcapi/api_objects/object_services/ranges.py
+++ b/fmcapi/api_objects/object_services/ranges.py
@@ -9,7 +9,8 @@ class Ranges(APIClassTemplate):
     """The Ranges Object in the FMC."""
 
     VALID_JSON_DATA = ["id", "name", "value", "description"]
-    VALID_FOR_KWARGS = VALID_JSON_DATA + []
+    VALID_GET_FILTERS = ["unusedOnly", "nameOrValue"] #unusedOnly:Bool, nameOrValue:String
+    VALID_FOR_KWARGS = VALID_JSON_DATA + VALID_GET_FILTERS + []
     URL_SUFFIX = "/object/ranges"
     REQUIRED_FOR_POST = ["name", "value"]
 

--- a/fmcapi/api_objects/object_services/urlgroups.py
+++ b/fmcapi/api_objects/object_services/urlgroups.py
@@ -9,7 +9,8 @@ class URLGroups(APIClassTemplate):
     """The URLGroups Object in the FMC."""
 
     VALID_JSON_DATA = ["id", "name", "type", "objects", "literals"]
-    VALID_FOR_KWARGS = VALID_JSON_DATA + []
+    VALID_GET_FILTERS = ["unusedOnly", "nameOrValue"] #unusedOnly:Bool, nameOrValue:String
+    VALID_FOR_KWARGS = VALID_JSON_DATA + VALID_GET_FILTERS + []
     URL_SUFFIX = "/object/urlgroups"
 
     # Technically you can have objects OR literals but I'm not set up for "OR" logic, yet.

--- a/fmcapi/api_objects/object_services/urls.py
+++ b/fmcapi/api_objects/object_services/urls.py
@@ -8,7 +8,8 @@ class URLs(APIClassTemplate):
     """The URLs Object in the FMC."""
 
     VALID_JSON_DATA = ["id", "name", "url", "description"]
-    VALID_FOR_KWARGS = VALID_JSON_DATA + []
+    VALID_GET_FILTERS = ["unusedOnly", "nameOrValue"] #unusedOnly:Bool, nameOrValue:String
+    VALID_FOR_KWARGS = VALID_JSON_DATA + VALID_GET_FILTERS + []
     URL_SUFFIX = "/object/urls"
     REQUIRED_FOR_POST = ["name", "url"]
 

--- a/fmcapi/api_objects/object_services/usage.py
+++ b/fmcapi/api_objects/object_services/usage.py
@@ -1,0 +1,27 @@
+"""Usage Class."""
+
+from fmcapi.api_objects.apiclasstemplate import APIClassTemplate
+from fmcapi.api_objects.helper_functions import *
+import logging
+
+
+class Usage(APIClassTemplate):
+    """The Usage Object in the FMC."""
+
+    VALID_JSON_DATA = []
+    VALID_GET_FILTERS = ["uuid", "type"] #uuid:String, type:String[Network,Port,VLAN,URL]
+    REQUIRED_GET_FILTERS = ["uuid", "type"]
+    VALID_FOR_KWARGS = VALID_JSON_DATA + VALID_GET_FILTERS + []
+    URL_SUFFIX = "/object/operational/usage"
+
+    def __init__(self, fmc, **kwargs):
+        """
+        Initialize Usage object.
+
+        :param fmc: (object) FMC object
+        :param kwargs: Any other values passed during instantiation.
+        :return: None
+        """
+        super().__init__(fmc, **kwargs)
+        logging.debug("In __init__() for Usage class.")
+        self.parse_kwargs(**kwargs)

--- a/fmcapi/api_objects/object_services/vlangrouptags.py
+++ b/fmcapi/api_objects/object_services/vlangrouptags.py
@@ -10,7 +10,8 @@ class VlanGroupTags(APIClassTemplate):
     """The VlanGroupTags Object in the FMC."""
 
     VALID_JSON_DATA = ["id", "name", "type", "description", "objects", "literals"]
-    VALID_FOR_KWARGS = VALID_JSON_DATA + []
+    VALID_GET_FILTERS = ["unusedOnly", "nameOrValue"] #unusedOnly:Bool, nameOrValue:String
+    VALID_FOR_KWARGS = VALID_JSON_DATA + VALID_GET_FILTERS + []
     URL_SUFFIX = "/object/vlangrouptags"
 
     # Technically you can have objects OR literals but I'm not set up for "OR" logic, yet.

--- a/fmcapi/api_objects/object_services/vlantags.py
+++ b/fmcapi/api_objects/object_services/vlantags.py
@@ -9,7 +9,8 @@ class VlanTags(APIClassTemplate):
     """The VlanTags Object in the FMC."""
 
     VALID_JSON_DATA = ["id", "name", "type", "data", "description"]
-    VALID_FOR_KWARGS = VALID_JSON_DATA + []
+    VALID_GET_FILTERS = ["unusedOnly", "nameOrValue"] #unusedOnly:Bool, nameOrValue:String
+    VALID_FOR_KWARGS = VALID_JSON_DATA + VALID_GET_FILTERS + []
     URL_SUFFIX = "/object/vlantags"
     REQUIRED_FOR_POST = ["name", "data"]
 

--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -31,6 +31,7 @@ from .acls_extended import test__extended_acls
 from .ip_range import test__ip_range
 from .ip_network import test__ip_network
 from .ip_host import test__ip_host
+from .objects_get_query_filters import test__objects_get_query_filters
 from .variable_set import test__variable_set
 from .server_version import test__fmc_version
 from .ip_addresses import test__ip_addresses
@@ -104,6 +105,7 @@ __all__ = [
     "test__fmc_version",
     "test__variable_set",
     "test__ip_host",
+    "test__objects_get_query_filters"
     "test__ip_network",
     "test__ip_range",
     "test__extended_acls",

--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -69,6 +69,7 @@ from .search_globalsearch import test__globalsearch
 from .search_object import test__object
 from .search_policy import test__policy
 from .backup import test__backup
+from .usage import test__usage
 
 logging.debug("In the unit-tests __init__.py file.")
 
@@ -142,4 +143,5 @@ __all__ = [
     "test__object",
     "test__policy",
     "test__backup",
+    "test__usage",
 ]

--- a/unit_tests/objects_get_query_filters.py
+++ b/unit_tests/objects_get_query_filters.py
@@ -1,0 +1,95 @@
+import logging
+import fmcapi
+import time
+import json
+
+
+def test__objects_get_query_filters(fmc):
+    logging.info("Test Object Get Query Filters.  Get Objects that support their various get query filters.")
+
+    #'_' in nameOrValue='_' is used as an example as we use underscores in our object names. 
+
+    logging.info('Object: Networks')
+    obj1 = fmcapi.Networks(fmc=fmc)
+    obj1.get(nameOrValue='_')
+    del obj1
+
+    logging.info('Object: Hosts')
+    obj1 = fmcapi.Hosts(fmc=fmc)
+    obj1.get(nameOrValue='_')
+    del obj1
+
+    logging.info('Object: NetworkGroups')
+    obj1 = fmcapi.NetworkGroups(fmc=fmc)
+    groups = obj1.get(nameOrValue='_')
+    print(json.dumps(groups, indent=2))
+    del obj1
+
+    logging.info('Object: Ports')
+    obj1 = fmcapi.Ports(fmc=fmc)
+    obj1.get(nameOrValue='_')
+    del obj1
+
+    logging.info('Object: ICMPv4Objects')
+    obj1 = fmcapi.ICMPv4Objects(fmc=fmc)
+    obj1.get(nameOrValue='_')
+    del obj1
+
+    logging.info('Object: ICMPv6Objects')
+    obj1 = fmcapi.ICMPv6Objects(fmc=fmc)
+    obj1.get(nameOrValue='_')
+    del obj1
+
+    logging.info('Object: ProtocolPortObjects')
+    obj1 = fmcapi.ProtocolPortObjects(fmc=fmc)
+    obj1.get(nameOrValue='_')
+    del obj1
+
+    logging.info('Object: PortObjectGroups')
+    obj1 = fmcapi.PortObjectGroups(fmc=fmc)
+    obj1.get(nameOrValue='_')
+    del obj1
+
+    logging.info('Object: VlanTags')
+    obj1 = fmcapi.VlanTags(fmc=fmc)
+    obj1.get(nameOrValue='_')
+    del obj1
+
+    logging.info('Object: VlanGroupTags')
+    obj1 = fmcapi.VlanGroupTags(fmc=fmc)
+    obj1.get(nameOrValue='_')
+    del obj1
+
+    logging.info('Object: URLs')
+    obj1 = fmcapi.URLs(fmc=fmc)
+    obj1.get(nameOrValue='_')
+    del obj1
+
+    logging.info('Object: URLGroups')
+    obj1 = fmcapi.URLGroups(fmc=fmc)
+    obj1.get(nameOrValue='_')
+    del obj1
+
+    logging.info('Object: NetworkAddresses')
+    obj1 = fmcapi.NetworkAddresses(fmc=fmc)
+    obj1.expanded = True
+    addresses = obj1.get(nameOrValue='_')
+    print(json.dumps(addresses, indent=2))
+    del obj1
+
+    logging.info('Object: Ranges')
+    obj1 = fmcapi.Ranges(fmc=fmc)
+    obj1.get(nameOrValue='_')
+    del obj1
+
+    logging.info('Object: FQDNs')
+    obj1 = fmcapi.FQDNS(fmc=fmc)
+    obj1.get(nameOrValue='_')
+    del obj1
+
+    logging.info('Object: AnyProtocolPortObjects')
+    obj1 = fmcapi.AnyProtocolPortObjects(fmc=fmc)
+    obj1.get(nameOrValue='_')
+    del obj1
+
+    logging.info("Test Object Get Query Filters done.\n")

--- a/unit_tests/usage.py
+++ b/unit_tests/usage.py
@@ -1,0 +1,25 @@
+import logging
+import fmcapi
+import time
+import json
+
+
+def test__usage(fmc):
+    logging.info("Test Object Find Usage.")
+
+    starttime = str(int(time.time()))
+    namer = f"_fmcapi_test_{starttime}"
+
+    obj1 = fmcapi.Hosts(fmc=fmc)
+    obj1.name = namer
+    obj1.value = "8.8.8.8/32"
+    obj1.post()
+    time.sleep(1)
+    obj2 = fmcapi.Usage(fmc=fmc)
+    obj2.get(uuid=obj1.id, type=obj1.type)
+    time.sleep(1)
+    obj1.delete()
+    del obj1
+    del obj2
+
+    logging.info("Test Object Find Usage done.\n")


### PR DESCRIPTION
This satisfies #159. 

I am not super thrilled with how I am currently handling the get query filters. Mainly it does not reuse `REQUIRED_FOR_GET` and creates some confusion between kwargs and self variables. I've looked through the OAS spec more and Cisco's query filters seem very arbitrary and tend to mix (cause confusion) with preexisting self variable names. 

Example: 
`/object/operational/usage` filter `uuid` is just referenced everywhere else as `id` 