### PR TITLE
add api_key support

### DIFF
--- a/fmcapi/fmc.py
+++ b/fmcapi/fmc.py
@@ -139,30 +139,22 @@ class FMC(object):
                 verify_cert=self.VERIFY_CERT,
                 timeout=self.timeout,
             )
-            self.uuid = self.mytoken.uuid
-            if self.mytoken.access_token:
-                self.build_urls()
-
-                version = ServerVersion(fmc=self)
-                version.get()
-                self.serverVersion = version.serverVersion
-                logging.info(f"This FMC's version is {self.serverVersion}")
-
-                return self
-            else:
+            if not self.mytoken.access_token:
                 logging.info("User authentication failed.")
                 exit(1)
+            self.uuid = self.mytoken.uuid
+
         else:
             if self.uuid is None:
                 logging.error("If using an API_KEY, you must provide a UUID")
                 exit(1)
 
-            self.build_urls()
-            version = ServerVersion(fmc=self)
-            version.get()
-            self.serverVersion = version.serverVersion
-            logging.info(f"This FMC's version is {self.serverVersion}")
-            return self
+        self.build_urls()
+        version = ServerVersion(fmc=self)
+        version.get()
+        self.serverVersion = version.serverVersion
+        logging.info(f"This FMC's version is {self.serverVersion}")
+        return self
 
     def __exit__(self, *args):
         """


### PR DESCRIPTION
[Cloud Delivered Firewall Management Centers (cdFMC)](https://www.cisco.com/c/en/us/td/docs/security/cdo/ftd-services-cdfmc-release-notes/cloud-delivered-firewall-management-center-release-notes/about-cloud-delivered-firewall-management-center.html) require use of API tokens to use the FMC REST API.  This pull request introduces support for usage of an `api_key` and `uuid` in the `FMC` object.

For now, if you're using an `api_key`, you must provide the `uuid` manually while creating the FMC object.  This domain `uuid` is pulled from the access token when using username/password with on-prem FMCs.

[cdFMC REST API info](https://www.cisco.com/c/en/us/td/docs/security/firepower/720/api/CDO_REST/cloud_delivered_firewall_management_center_rest_api_quick_start_guide_720/Connecting_With_A_Client.html)

Example usage:

```python
with fmcapi.FMC(
            host=fmc_ip,
            api_key="my_api_key",
            uuid="my_domain_uuid",
            autodeploy=False
        ) as fmc:
```

-jw