### PR TITLE
Support for terminatingravpnsessions

### DIFF
--- a/fmcapi/api_objects/__init__.py
+++ b/fmcapi/api_objects/__init__.py
@@ -25,6 +25,7 @@ from .device_services.physicalinterfaces import PhysicalInterfaces
 from .device_services.redundantinterfaces import RedundantInterfaces
 from .device_services.staticroutes import StaticRoutes
 from .device_services.subinterfaces import SubInterfaces
+from .health.terminateravpnsessions import TerminateRAVPNSessions
 from .object_services.anyprotocolportobjects import AnyProtocolPortObjects
 from .object_services.applicationcategories import ApplicationCategories
 from .object_services.applicationfilters import ApplicationFilters
@@ -206,4 +207,5 @@ __all__ = [
     "Usage",
     "DynamicObject",
     "DynamicObjectMappings",
+    "TerminateRAVPNSessions",
 ]

--- a/fmcapi/api_objects/health/__init__.py
+++ b/fmcapi/api_objects/health/__init__.py
@@ -1,0 +1,8 @@
+"""Health Classes."""
+
+import logging
+from .terminateravpnsessions import TerminateRAVPNSessions
+
+logging.debug("In the health __init__.py file.")
+
+__all__ = ["Health"]

--- a/fmcapi/api_objects/health/terminateravpnsessions.py
+++ b/fmcapi/api_objects/health/terminateravpnsessions.py
@@ -1,0 +1,51 @@
+from fmcapi.api_objects.apiclasstemplate import APIClassTemplate
+import logging
+
+class TerminateRAVPNSessions(APIClassTemplate):
+    """The TerminateRAVPNSessions Object in the FMC."""
+
+    FIRST_SUPPORTED_FMC_VERSION = "7.3"
+    VALID_JSON_DATA = [
+        "id",
+        "name",
+        "description",
+        "usernames",
+        "type",
+        "deviceId",
+        "terminateBy",
+        "sessionIds",
+        "version"
+    ]
+    VALID_FOR_KWARGS = VALID_JSON_DATA + []
+    REQUIRED_FOR_POST = [
+        "terminateBy"
+    ]
+
+    URL_SUFFIX = "/health/ravpnsessions/operational/terminateravpnsessions"
+
+    def __init__(self, fmc, **kwargs):
+        """
+        Initialize TerminateRAVPNSessions object.
+
+        :param fmc (object): FMC object
+        :param **kwargs: Any other values passed during instantiation.
+        :return: requests response
+        """
+        super().__init__(fmc, **kwargs)
+        logging.debug("In __init__() for TerminateRAVPNSessions class.")
+        self.parse_kwargs(**kwargs)
+
+    def get(self, **kwargs):
+        """GET method for API for TerminateRAVPNSessions not supported."""
+        logging.info("GET method for API for TerminateRAVPNSessions not supported.")
+        pass
+
+    def delete(self, **kwargs):
+        """DELETE method for API for TerminateRAVPNSessions not supported."""
+        logging.info("DELETE method for API for TerminateRAVPNSessions not supported.")
+        pass
+
+    def put(self):
+        """PUT method for API for TerminateRAVPNSessions not supported."""
+        logging.info("PUT method for API for TerminateRAVPNSessions not supported.")
+        pass

--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -72,6 +72,7 @@ from .backup import test__backup
 from .usage import test__usage
 from .dynamic_objects import test__dynamic_objects
 from .dynamic_object_mappings import test__dynamic_objects_mappings
+from .terminateravpnsessions import test__terminateravpnsessions
 
 logging.debug("In the unit-tests __init__.py file.")
 
@@ -148,4 +149,5 @@ __all__ = [
     "test__usage",
     "test__dynamic_objects",
     "test__dynamic_objects_mappings",
+    "test__terminateravpnsessions",
 ]

--- a/unit_tests/terminateravpnsessions.py
+++ b/unit_tests/terminateravpnsessions.py
@@ -30,11 +30,3 @@ def test__terminateravpnsessions(fmc):
     del(obj1)
 
     logging.info("Test TerminateRAVPNSessions done.\n")
-
-# {
-#   "usernames": [
-#     "testuser"
-#   ],
-#   "terminateBy": "USER",
-#   "deviceId": "$device_id_not_device_ha_id"
-# }

--- a/unit_tests/terminateravpnsessions.py
+++ b/unit_tests/terminateravpnsessions.py
@@ -1,0 +1,40 @@
+import logging
+import fmcapi
+
+
+def test__terminateravpnsessions(fmc):
+    logging.info("Test TerminateRAVPNSessions. Requires an existing session id, user, or user+device id")
+    logging.info("Terminating many sessions at once, like all sessions on a device, will likely require increasing fmc timeout")
+
+    obj1 = fmcapi.TerminateRAVPNSessions(fmc=fmc)
+    ######DIFFERENT TERMINATION METHODS##########
+    # Terminate user/users on a specific deivce
+    usernames_to_terminate = ['zlantztest']
+    device_id = "5fceadc2-ffef-11ed-94e9-8f60148d3f9b"
+    obj1.terminateBy = "USER"
+    obj1.usernames = usernames_to_terminate
+    obj1.deviceId = device_id
+
+    # Terminate by specific session id
+    # Currently have not found a reliable way of getting ravpnsession ids since there is no get methods for ravpnsessions
+    # I have already complained about this to the BU
+    # obj1.terminateBy = "SESSION"
+
+    # Terminate all sessions on device
+    # device_id = "5fceadc2-ffef-11ed-94e9-8f60148d3f9b"
+    # obj1.terminateBy = "DEVICE"
+    # obj1.deviceId = device_id
+
+    result = obj1.post()
+    logging.info(result)
+    del(obj1)
+
+    logging.info("Test TerminateRAVPNSessions done.\n")
+
+# {
+#   "usernames": [
+#     "testuser"
+#   ],
+#   "terminateBy": "USER",
+#   "deviceId": "$device_id_not_device_ha_id"
+# }


### PR DESCRIPTION
This adds support for terminating RA VPN sessions. The documentation for this api endpoint is pretty broken and there is no get method. This has been reported to Cisco, but currently, I got this working with some trial and error. 