### PR TITLE
Support for RAVPN Policies and a couple of its child policies. Devicerecords getfilter

### DIFF
--- a/TestingUserScript.py
+++ b/TestingUserScript.py
@@ -82,7 +82,8 @@ def main():
         # unit_tests.test__usage(fmc=fmc1)
         # unit_tests.test__dynamic_objects(fmc=fmc1)
         # unit_tests.test__dynamic_objects_mappings(fmc=fmc1)
-
+        # unit_tests.test__grouppolicies(fmc=fmc1)
+        # unit_tests.test__ravpn(fmc=fmc1)
 
 
         """

--- a/TestingUserScript.py
+++ b/TestingUserScript.py
@@ -84,6 +84,8 @@ def main():
         # unit_tests.test__dynamic_objects_mappings(fmc=fmc1)
         # unit_tests.test__grouppolicies(fmc=fmc1)
         # unit_tests.test__ravpn(fmc=fmc1)
+        # unit_tests.test__connectionprofiles(fmc=fmc1) # Requires existing RAVPN Policy ID
+        # unit_tests.test__dynamicaccesspolicies(fmc=fmc1)
 
 
         """

--- a/fmcapi/api_objects/__init__.py
+++ b/fmcapi/api_objects/__init__.py
@@ -108,6 +108,7 @@ from .object_services.dynamicobjectmappings import DynamicObjectMappings
 from .object_services.grouppolicies import GroupPolicies
 from .policy_services.ravpns import RAVpn
 from .policy_services import ConnectionProfiles
+from .policy_services import DynamicAccessPolicies
 
 logging.debug("In the api_objects __init__.py file.")
 
@@ -214,4 +215,5 @@ __all__ = [
     "GroupPolicies",
     "RAVpn",
     "ConnectionProfiles",
+    "DynamicAccessPolicies",
 ]

--- a/fmcapi/api_objects/__init__.py
+++ b/fmcapi/api_objects/__init__.py
@@ -106,6 +106,7 @@ from .update_packages.upgradepackages import UpgradePackages
 from .object_services.dynamicobjects import DynamicObject
 from .object_services.dynamicobjectmappings import DynamicObjectMappings
 from .object_services.grouppolicies import GroupPolicies
+from .policy_services.ravpns import RAVpn
 
 logging.debug("In the api_objects __init__.py file.")
 
@@ -209,5 +210,6 @@ __all__ = [
     "DynamicObject",
     "DynamicObjectMappings",
     "TerminateRAVPNSessions",
-    "GroupPolicies"
+    "GroupPolicies",
+    "RAVpn",
 ]

--- a/fmcapi/api_objects/__init__.py
+++ b/fmcapi/api_objects/__init__.py
@@ -107,6 +107,7 @@ from .object_services.dynamicobjects import DynamicObject
 from .object_services.dynamicobjectmappings import DynamicObjectMappings
 from .object_services.grouppolicies import GroupPolicies
 from .policy_services.ravpns import RAVpn
+from .policy_services import ConnectionProfiles
 
 logging.debug("In the api_objects __init__.py file.")
 
@@ -212,4 +213,5 @@ __all__ = [
     "TerminateRAVPNSessions",
     "GroupPolicies",
     "RAVpn",
+    "ConnectionProfiles",
 ]

--- a/fmcapi/api_objects/__init__.py
+++ b/fmcapi/api_objects/__init__.py
@@ -105,6 +105,7 @@ from .update_packages.upgradepackage import Upgrades
 from .update_packages.upgradepackages import UpgradePackages
 from .object_services.dynamicobjects import DynamicObject
 from .object_services.dynamicobjectmappings import DynamicObjectMappings
+from .object_services.grouppolicies import GroupPolicies
 
 logging.debug("In the api_objects __init__.py file.")
 
@@ -208,4 +209,5 @@ __all__ = [
     "DynamicObject",
     "DynamicObjectMappings",
     "TerminateRAVPNSessions",
+    "GroupPolicies"
 ]

--- a/fmcapi/api_objects/device_services/devicerecords.py
+++ b/fmcapi/api_objects/device_services/devicerecords.py
@@ -21,7 +21,18 @@ class DeviceRecords(APIClassTemplate):
         "performanceTier",
         "accessPolicy",
     ]
-    VALID_FOR_KWARGS = VALID_JSON_DATA + [
+    VALID_GET_FILTERS = [
+        # TODO: name as a get filter will conflict with existing logic to look something up by name - use hostname instead for now
+        # "name", # String
+        "hostName", # String
+        "serialNumber", # String
+        "containerType", # DeviceCluster|DeviceHAPair|DeviceStack
+        "clusterBootstrapSupported", # Bool
+        "analyticsOnly", # Bool
+        "includeOtherAssociatedPolicies", # Bool
+        "modeType" # NGFW|Chassis
+    ]
+    VALID_FOR_KWARGS = VALID_JSON_DATA + VALID_GET_FILTERS + [
         "acp_name",
         "acp_id",
         "model",
@@ -38,6 +49,7 @@ class DeviceRecords(APIClassTemplate):
         "keepLocalEvents",
         "ftdMode",
         "keepLocalEvents",
+        "expanded"
     ]
     URL_SUFFIX = "/devices/devicerecords"
     REQUIRED_FOR_POST = ["accessPolicy", "hostName", "regKey", "type"]

--- a/fmcapi/api_objects/object_services/__init__.py
+++ b/fmcapi/api_objects/object_services/__init__.py
@@ -52,6 +52,7 @@ from .vlangrouptags import VlanGroupTags
 from .vlantags import VlanTags
 from .dynamicobjects import DynamicObject
 from .dynamicobjectmappings import DynamicObjectMappings
+from .grouppolicies import GroupPolicies
 
 logging.debug("In the object_services __init__.py file.")
 
@@ -73,6 +74,7 @@ __all__ = [
     "ExtendedAccessListAce",
     "FQDNS",
     "Geolocation",
+    "GroupPolicies",
     "Hosts",
     "ICMPv4Objects",
     "ICMPv6Objects",

--- a/fmcapi/api_objects/object_services/grouppolicies.py
+++ b/fmcapi/api_objects/object_services/grouppolicies.py
@@ -1,0 +1,47 @@
+"""Group Policies Class."""
+
+from fmcapi.api_objects.apiclasstemplate import APIClassTemplate
+import logging
+
+
+class GroupPolicies(APIClassTemplate):
+    """The GroupPolicies Object in the FMC."""
+
+    VALID_JSON_DATA = [
+        "id",
+        "name",
+        "type",
+        "generalSettings", # Dict
+        "anyConnectSettings", # Dict
+        "advancedSettings", # Dict
+        "enableSSLProtocol", # Bool
+        "enableIPsecIKEv2Protocol", # Bool
+    ]
+    VALID_GET_FILTERS = [
+        "unusedOnly", # Bool
+        "nameOrValue", # String
+    ]
+    VALID_FOR_KWARGS = VALID_JSON_DATA + VALID_GET_FILTERS + []
+    URL_SUFFIX = "/object/grouppolicies"
+    REQUIRED_FOR_PUT = [
+        "id",
+        "name",
+        "generalSettings", # Dict
+        "anyConnectSettings", # Dict
+        "advancedSettings", # Dict
+        "enableSSLProtocol", # Bool
+        "enableIPsecIKEv2Protocol", # Bool
+    ]
+
+    def __init__(self, fmc, **kwargs):
+        """
+        Initialize GroupPolicies object.
+
+        :param fmc: (object) FMC object
+        :param kwargs: Any other values passed during instantiation.
+        :return: None
+        """
+        super().__init__(fmc, **kwargs)
+        logging.debug("In __init__() for GroupPolicies class.")
+        self.type = "GroupPolicy"
+        self.parse_kwargs(**kwargs)

--- a/fmcapi/api_objects/policy_services/__init__.py
+++ b/fmcapi/api_objects/policy_services/__init__.py
@@ -21,6 +21,7 @@ from .prefilterpolicies import PreFilterPolicies
 from .inheritancesettings import InheritanceSettings
 from .ravpns import RAVpn
 from .connectionprofiles import ConnectionProfiles
+from .dynamicaccesspolicies import DynamicAccessPolicies
 
 logging.debug("In the object_services __init__.py file.")
 
@@ -45,4 +46,5 @@ __all__ = [
     "InheritanceSettings",
     "RAVpn",
     "ConnectionProfiles",
+    "DynamicAccessPolicies",
 ]

--- a/fmcapi/api_objects/policy_services/__init__.py
+++ b/fmcapi/api_objects/policy_services/__init__.py
@@ -20,6 +20,7 @@ from .natrules import NatRules
 from .prefilterpolicies import PreFilterPolicies
 from .inheritancesettings import InheritanceSettings
 from .ravpns import RAVpn
+from .connectionprofiles import ConnectionProfiles
 
 logging.debug("In the object_services __init__.py file.")
 
@@ -43,4 +44,5 @@ __all__ = [
     "DefaultActions",
     "InheritanceSettings",
     "RAVpn",
+    "ConnectionProfiles",
 ]

--- a/fmcapi/api_objects/policy_services/__init__.py
+++ b/fmcapi/api_objects/policy_services/__init__.py
@@ -19,6 +19,7 @@ from .manualnatrules import ManualNatRules
 from .natrules import NatRules
 from .prefilterpolicies import PreFilterPolicies
 from .inheritancesettings import InheritanceSettings
+from .ravpns import RAVpn
 
 logging.debug("In the object_services __init__.py file.")
 
@@ -41,4 +42,5 @@ __all__ = [
     "HitCounts",
     "DefaultActions",
     "InheritanceSettings",
+    "RAVpn",
 ]

--- a/fmcapi/api_objects/policy_services/connectionprofiles.py
+++ b/fmcapi/api_objects/policy_services/connectionprofiles.py
@@ -1,0 +1,69 @@
+"""ConnectionProfiles Class."""
+
+from fmcapi.api_objects.apiclasstemplate import APIClassTemplate
+import logging
+
+
+class ConnectionProfiles(APIClassTemplate):
+    """The ConnectionProfiles Object in the FMC."""
+
+    REQUIRED_FOR_GET = ["container_uuid"]
+    REQUIRED_FOR_POST = ["container_uuid","name"]
+    REQUIRED_FOR_PUT = ["container_uuid", "id"]
+    REQUIRED_FOR_DELETE = ["container_uuid", "id"]
+    VALID_JSON_DATA = [
+        "id",
+        "name",
+        "type",
+        "groupPolicy",
+        "authenticationMethod",
+        "ipv4AddressPool",
+        "enableSecondaryAuthentication",
+        "enableSecondaryAuthFallbackToLocal",
+        "useLocalAsSecondaryAuthServer",
+        "enablePrimaryAuthFallbackToLocal",
+        "useLocalAsPrimaryAuthServer",
+        "primaryAuthenticationServer",
+        "allowConnectionOnlyIfAuthorized",
+        "enablePasswordManagement",
+        "stripGroupFromUsername",
+        "stripRealmFromUsername"
+    ]
+    VALID_FOR_KWARGS = VALID_JSON_DATA  + ["container_uuid"]
+    URL_SUFFIX = "/policy/ravpns"
+    FIRST_SUPPORTED_FMC_VERSION = "7.2"
+
+    def __init__(self, fmc, **kwargs):
+        """
+        Initialize ConnectionProfiles object.
+
+        :param fmc: (object) FMC object
+        :param kwargs: Any other values passed during instantiation.
+        :return: None
+        """
+        super().__init__(fmc, **kwargs)
+        logging.debug("In __init__() for ConnectionProfiles class.")
+        self.type = "ConnectionProfiles"
+        self.parse_kwargs(**kwargs)
+        URL_CONTAINER_SUFFIX = f"/{self.container_uuid}/connectionprofiles"
+        self.URL = self.URL + URL_CONTAINER_SUFFIX
+
+    # POST, PUT and DELETE are valid endpoints in the api >7.4.1, however POST has a cycical dependency
+    # with serveral other api endpoints - connectionprofiles, addressassignments, etc.
+    # This is due to needing a container uuid of the ConnectionProfiles policy but also needing those objects to
+    # create the ConnectionProfiles policy in the first place.
+
+    def post(self):
+        """POST method for API for ConnectionProfiles not supported."""
+        logging.info("POST method for API for ConnectionProfiles not supported.")
+        pass
+
+    # def put(self):
+    #     """PUT method for API for ConnectionProfiles not supported."""
+    #     logging.info("PUT method for API for ConnectionProfiles not supported.")
+    #     pass
+
+    def delete(self):
+        """DELETE method for API for ConnectionProfiles not supported."""
+        logging.info("DELETE method for API for ConnectionProfiles not supported.")
+        pass

--- a/fmcapi/api_objects/policy_services/connectionprofiles.py
+++ b/fmcapi/api_objects/policy_services/connectionprofiles.py
@@ -47,23 +47,3 @@ class ConnectionProfiles(APIClassTemplate):
         self.parse_kwargs(**kwargs)
         URL_CONTAINER_SUFFIX = f"/{self.container_uuid}/connectionprofiles"
         self.URL = self.URL + URL_CONTAINER_SUFFIX
-
-    # POST, PUT and DELETE are valid endpoints in the api >7.4.1, however POST has a cycical dependency
-    # with serveral other api endpoints - connectionprofiles, addressassignments, etc.
-    # This is due to needing a container uuid of the ConnectionProfiles policy but also needing those objects to
-    # create the ConnectionProfiles policy in the first place.
-
-    def post(self):
-        """POST method for API for ConnectionProfiles not supported."""
-        logging.info("POST method for API for ConnectionProfiles not supported.")
-        pass
-
-    # def put(self):
-    #     """PUT method for API for ConnectionProfiles not supported."""
-    #     logging.info("PUT method for API for ConnectionProfiles not supported.")
-    #     pass
-
-    def delete(self):
-        """DELETE method for API for ConnectionProfiles not supported."""
-        logging.info("DELETE method for API for ConnectionProfiles not supported.")
-        pass

--- a/fmcapi/api_objects/policy_services/dynamicaccesspolicies.py
+++ b/fmcapi/api_objects/policy_services/dynamicaccesspolicies.py
@@ -1,0 +1,124 @@
+"""DynamicAccessPolicies Class."""
+
+from fmcapi.api_objects.apiclasstemplate import APIClassTemplate
+import logging
+import xmltodict
+import base64
+
+
+class DynamicAccessPolicies(APIClassTemplate):
+    """The DynamicAccessPolicies Object in the FMC."""
+    REQUIRED_FOR_PUT = [
+        "id",
+        "authorizationAttributes",
+        "dapXmlConfig_dict",
+        "hostscanXmlConfig_dict",
+    ]
+    VALID_JSON_DATA = [
+        "id",
+        "name",
+        "type",
+        "authorizationAttributes",
+        "dapXmlConfig",
+        "hostscanXmlConfig",
+    ]
+    VALID_FOR_KWARGS = VALID_JSON_DATA + []
+    URL_SUFFIX = "/policy/dynamicaccesspolicies"
+    FIRST_SUPPORTED_FMC_VERSION = "7.2"
+
+    def __init__(self, fmc, **kwargs):
+        """
+        Initialize DynamicAccessPolicies object.
+
+        :param fmc: (object) FMC object
+        :param kwargs: Any other values passed during instantiation.
+        :return: None
+        """
+        super().__init__(fmc, **kwargs)
+        logging.debug("In __init__() for DynamicAccessPolicies class.")
+        self.type = "DynamicAccessPolicy"
+        self.parse_kwargs(**kwargs)
+
+    def unpack_xml_config(self, encoded_xml):
+
+        """
+        Unpack and reformat base64 encoded xml from DAP api responses
+
+        Args:
+            encoded_xml (string): base64 encoded xml string from either dapXmlConfig or hostscanXmlConfig
+
+        Returns:
+            dict: base64 decoded 'encoded_xml' represented as a dict instead of xml
+        """
+
+        decoded_xml = base64.b64decode(encoded_xml).decode("utf-8")
+        xml_dict = xmltodict.parse(decoded_xml)
+
+        return xml_dict
+
+    def repack_xml_config(self, xml_dict):
+
+        """Repack dict into xml and encoded for use with DAP api calls
+
+        Args:
+            xml_dict (_type_): _description_
+
+        Returns:
+            _type_: _description_
+        """
+
+        xml = xmltodict.unparse(xml_dict)
+        encoded_xml_bytes = base64.b64encode(xml.encode("utf-8"))
+        encoded_xml_string = encoded_xml_bytes.decode("utf-8")
+
+        return encoded_xml_string
+
+    def get(self, **kwargs):
+
+        """
+        Modified get() for DynamicAccessPolicies class to make working with
+        dapXmlConfig and hostscanXmlConfig a bit easier. This will create self.dapXmlConfig_dict
+        and self.hostscanXmlConfig_dict from the base64 encoded xml from the api repsonse.
+        """
+
+        super().get(**kwargs)
+        logging.debug("In get() for DynamicAccessPolicies class.")
+        if hasattr(self, 'dapXmlConfig'):
+            self.dapXmlConfig_dict = self.unpack_xml_config(self.dapXmlConfig)
+
+        if hasattr(self, 'hostscanXmlConfig'):
+            self.hostscanXmlConfig_dict = self.unpack_xml_config(self.hostscanXmlConfig)
+
+    def post(self, **kwargs):
+
+        """
+        Modified post() for DynamicAccessPolicies class to make working with
+        dapXmlConfig and hostscanXmlConfig a bit easier. This will take self.dapXmlConfig_dict
+        and self.hostscanXmlConfig_dict and convert to xml before base64 encoding for use with api endpoint.
+        """
+
+        if hasattr(self, 'dapXmlConfig_dict'):
+            self.dapXmlConfig = self.repack_xml_config(self.dapXmlConfig_dict)
+
+        if hasattr(self, 'hostscanXmlConfig_dict'):
+            self.hostscanXmlConfig = self.repack_xml_config(self.hostscanXmlConfig_dict)
+
+        super().post(**kwargs)
+        logging.debug("In post() for DynamicAccessPolicies class.")
+
+    def put(self, **kwargs):
+
+        """
+        Modified put() for DynamicAccessPolicies class to make working with
+        dapXmlConfig and hostscanXmlConfig a bit easier. This will take self.dapXmlConfig_dict
+        and self.hostscanXmlConfig_dict and convert to xml before base64 encoding for use with api endpoint.
+        """
+
+        if hasattr(self, 'dapXmlConfig_dict'):
+            self.dapXmlConfig = self.repack_xml_config(self.dapXmlConfig_dict)
+
+        if hasattr(self, 'hostscanXmlConfig_dict'):
+            self.hostscanXmlConfig = self.repack_xml_config(self.hostscanXmlConfig_dict)
+
+        super().put(**kwargs)
+        logging.debug("In put() for DynamicAccessPolicies class.")

--- a/fmcapi/api_objects/policy_services/ravpns.py
+++ b/fmcapi/api_objects/policy_services/ravpns.py
@@ -6,7 +6,6 @@ import logging
 
 class RAVpn(APIClassTemplate):
     """The RAVpn Object in the FMC."""
-
     VALID_JSON_DATA = [
         "id",
         "name",
@@ -45,7 +44,7 @@ class RAVpn(APIClassTemplate):
         self.type = "RAVpn"
         self.parse_kwargs(**kwargs)
 
-    # POST, PUT and DELETE are valid endpoints in the api >7.4.1, however POST has a cycical dependency
+    # POST, PUT and DELETE are valid endpoints in the api >7.2, however ravpn POST has a cycical dependency
     # with serveral other api endpoints - connectionprofiles, addressassignments, etc.
     # This is due to needing a container uuid of the RAVPN policy but also needing those objects to
     # create the RAVPN policy in the first place.
@@ -53,14 +52,4 @@ class RAVpn(APIClassTemplate):
     def post(self):
         """POST method for API for RAVPN not supported."""
         logging.info("POST method for API for RAVPN not supported.")
-        pass
-
-    def put(self):
-        """PUT method for API for RAVPN not supported."""
-        logging.info("PUT method for API for RAVPN not supported.")
-        pass
-
-    def delete(self):
-        """DELETE method for API for RAVPN not supported."""
-        logging.info("DELETE method for API for RAVPN not supported.")
         pass

--- a/fmcapi/api_objects/policy_services/ravpns.py
+++ b/fmcapi/api_objects/policy_services/ravpns.py
@@ -1,0 +1,66 @@
+"""RAVpn Class."""
+
+from fmcapi.api_objects.apiclasstemplate import APIClassTemplate
+import logging
+
+
+class RAVpn(APIClassTemplate):
+    """The RAVpn Object in the FMC."""
+
+    VALID_JSON_DATA = [
+        "id",
+        "name",
+        "type",
+        "connectionProfiles",
+        "groupPolicies",
+        "accessInterfaceSettings",
+        "ikev2Policies",
+        "addressAssignmentSettings",
+        "anyConnectClientImages",
+        "externalBrowserPackage",
+        "ipsecCryptoMaps",
+        "certificateMapSettings",
+        "ipsecAdvancedSettings",
+        "secureClientCustomizationSettings",
+        "dapPolicy",
+        "ldapAttributeMaps",
+        "loadBalanceSettings",
+        "configureSSL",
+        "configureIpsec"
+    ]
+    VALID_FOR_KWARGS = VALID_JSON_DATA + []
+    URL_SUFFIX = "/policy/ravpns"
+    FIRST_SUPPORTED_FMC_VERSION = "7.2"
+
+    def __init__(self, fmc, **kwargs):
+        """
+        Initialize RAVpn object.
+
+        :param fmc: (object) FMC object
+        :param kwargs: Any other values passed during instantiation.
+        :return: None
+        """
+        super().__init__(fmc, **kwargs)
+        logging.debug("In __init__() for RAVPN class.")
+        self.type = "RAVpn"
+        self.parse_kwargs(**kwargs)
+
+    # POST, PUT and DELETE are valid endpoints in the api >7.4.1, however POST has a cycical dependency
+    # with serveral other api endpoints - connectionprofiles, addressassignments, etc.
+    # This is due to needing a container uuid of the RAVPN policy but also needing those objects to
+    # create the RAVPN policy in the first place.
+
+    def post(self):
+        """POST method for API for RAVPN not supported."""
+        logging.info("POST method for API for RAVPN not supported.")
+        pass
+
+    def put(self):
+        """PUT method for API for RAVPN not supported."""
+        logging.info("PUT method for API for RAVPN not supported.")
+        pass
+
+    def delete(self):
+        """DELETE method for API for RAVPN not supported."""
+        logging.info("DELETE method for API for RAVPN not supported.")
+        pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 idna==2.10
 requests
 ipaddress
+xmltodict

--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -74,6 +74,7 @@ from .dynamic_objects import test__dynamic_objects
 from .dynamic_object_mappings import test__dynamic_objects_mappings
 from .terminateravpnsessions import test__terminateravpnsessions
 from .grouppolicies import test__grouppolicies
+from .ravpn import test__ravpn
 
 logging.debug("In the unit-tests __init__.py file.")
 
@@ -151,5 +152,6 @@ __all__ = [
     "test__dynamic_objects",
     "test__dynamic_objects_mappings",
     "test__terminateravpnsessions",
-    "test__grouppolicies"
+    "test__grouppolicies",
+    "test__ravpn",
 ]

--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -76,6 +76,7 @@ from .terminateravpnsessions import test__terminateravpnsessions
 from .grouppolicies import test__grouppolicies
 from .ravpn import test__ravpn
 from .connectionprofiles import test__connectionprofiles
+from .dynamicaccesspolicies import test__dynamicaccesspolicies
 
 logging.debug("In the unit-tests __init__.py file.")
 
@@ -156,4 +157,5 @@ __all__ = [
     "test__grouppolicies",
     "test__ravpn",
     "test__connectionprofiles",
+    "test__dynamicaccesspolicies",
 ]

--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -73,6 +73,7 @@ from .usage import test__usage
 from .dynamic_objects import test__dynamic_objects
 from .dynamic_object_mappings import test__dynamic_objects_mappings
 from .terminateravpnsessions import test__terminateravpnsessions
+from .grouppolicies import test__grouppolicies
 
 logging.debug("In the unit-tests __init__.py file.")
 
@@ -150,4 +151,5 @@ __all__ = [
     "test__dynamic_objects",
     "test__dynamic_objects_mappings",
     "test__terminateravpnsessions",
+    "test__grouppolicies"
 ]

--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -75,6 +75,7 @@ from .dynamic_object_mappings import test__dynamic_objects_mappings
 from .terminateravpnsessions import test__terminateravpnsessions
 from .grouppolicies import test__grouppolicies
 from .ravpn import test__ravpn
+from .connectionprofiles import test__connectionprofiles
 
 logging.debug("In the unit-tests __init__.py file.")
 
@@ -154,4 +155,5 @@ __all__ = [
     "test__terminateravpnsessions",
     "test__grouppolicies",
     "test__ravpn",
+    "test__connectionprofiles",
 ]

--- a/unit_tests/connectionprofiles.py
+++ b/unit_tests/connectionprofiles.py
@@ -1,0 +1,48 @@
+import logging
+import fmcapi
+import time
+import json
+
+def test__connectionprofiles(fmc):
+    logging.info("Testing ConnectionProfiles class.")
+
+    starttime = str(int(time.time()))
+    namer = f"_fmcapi_test_{starttime}"
+
+    connection_profiles = fmcapi.ConnectionProfiles(fmc=fmc, container_uuid="40A6B737-FDDC-0ed3-0000-227633610030")
+    conn_profs = connection_profiles.get(expanded=True)
+    logging.info(conn_profs)
+    for item in conn_profs.get('items'):
+        conn_profile_id = item.get('id')
+        profile = fmcapi.ConnectionProfiles(fmc=fmc, container_uuid="40A6B737-FDDC-0ed3-0000-227633610030")
+        profile.id = conn_profile_id
+        conn_prof = profile.get(expanded=True)
+        logging.info(f"current groupPolicy: {conn_prof.get('groupPolicy')}")
+        lock_out_grp_pol = {
+            'name': 'LOCKOUT_GRP_POL',
+            'id': '40A6B737-FDDC-0ed3-0000-227637209390',
+            'type': 'GroupPolicy'
+        }
+        profile.groupPolicy = lock_out_grp_pol
+        profile.put()
+
+    logging.info(json.dumps(conn_prof, indent=2))
+
+
+    # ravpn_policies = fmcapi.RAVpn(fmc=fmc)
+    # logging.info(f'Looking for all RAVPN Policies')
+    # all_ravpn_policies = ravpn_policies.get()
+    # logging.info(f'Found {len(all_ravpn_policies.get("items"))} RAVPN Policies')
+
+    # for policy in all_ravpn_policies.get('items'):
+    #     ravpn_policy = fmcapi.RAVpn(fmc=fmc)
+    #     ravpn_policy.id = policy.get('id')
+    #     ravpn_policy.get(expanded=True)
+    #     logging.info(f'Found {ravpn_policy.name} with ID of {ravpn_policy.id}')
+
+    # POST, PUT and DELETE are valid endpoints in the api >7.2, however ravpn POST has a cycical dependency
+    # with serveral other api endpoints - connectionprofiles, addressassignments, etc.
+    # This is due to needing a container uuid of the RAVPN policy but also needing those objects to
+    # create the RAVPN policy in the first place.
+
+    logging.info("Testing ConnectionProfiles class done.\n")

--- a/unit_tests/connectionprofiles.py
+++ b/unit_tests/connectionprofiles.py
@@ -10,39 +10,21 @@ def test__connectionprofiles(fmc):
     namer = f"_fmcapi_test_{starttime}"
 
     connection_profiles = fmcapi.ConnectionProfiles(fmc=fmc, container_uuid="40A6B737-FDDC-0ed3-0000-227633610030")
-    conn_profs = connection_profiles.get(expanded=True)
-    logging.info(conn_profs)
-    for item in conn_profs.get('items'):
-        conn_profile_id = item.get('id')
-        profile = fmcapi.ConnectionProfiles(fmc=fmc, container_uuid="40A6B737-FDDC-0ed3-0000-227633610030")
-        profile.id = conn_profile_id
-        conn_prof = profile.get(expanded=True)
-        logging.info(f"current groupPolicy: {conn_prof.get('groupPolicy')}")
-        lock_out_grp_pol = {
-            'name': 'LOCKOUT_GRP_POL',
-            'id': '40A6B737-FDDC-0ed3-0000-227637209390',
-            'type': 'GroupPolicy'
-        }
-        profile.groupPolicy = lock_out_grp_pol
-        profile.put()
+    connection_profiles.get(expanded=True)
 
-    logging.info(json.dumps(conn_prof, indent=2))
-
-
-    # ravpn_policies = fmcapi.RAVpn(fmc=fmc)
-    # logging.info(f'Looking for all RAVPN Policies')
-    # all_ravpn_policies = ravpn_policies.get()
-    # logging.info(f'Found {len(all_ravpn_policies.get("items"))} RAVPN Policies')
-
-    # for policy in all_ravpn_policies.get('items'):
-    #     ravpn_policy = fmcapi.RAVpn(fmc=fmc)
-    #     ravpn_policy.id = policy.get('id')
-    #     ravpn_policy.get(expanded=True)
-    #     logging.info(f'Found {ravpn_policy.name} with ID of {ravpn_policy.id}')
-
-    # POST, PUT and DELETE are valid endpoints in the api >7.2, however ravpn POST has a cycical dependency
-    # with serveral other api endpoints - connectionprofiles, addressassignments, etc.
-    # This is due to needing a container uuid of the RAVPN policy but also needing those objects to
-    # create the RAVPN policy in the first place.
+    # Example to change group policy in an existing connection profile
+    # for item in conn_profs.get('items'):
+    #     conn_profile_id = item.get('id')
+    #     profile = fmcapi.ConnectionProfiles(fmc=fmc, container_uuid="40A6B737-FDDC-0ed3-0000-227633610030")
+    #     profile.id = conn_profile_id
+    #     conn_prof = profile.get(expanded=True)
+    #     logging.info(f"current groupPolicy: {conn_prof.get('groupPolicy')}")
+    #     lock_out_grp_pol = {
+    #         'name': 'LOCKOUT_GRP_POL',
+    #         'id': '40A6B737-FDDC-0ed3-0000-227637209390',
+    #         'type': 'GroupPolicy'
+    #     }
+    #     profile.groupPolicy = lock_out_grp_pol
+    #     profile.put()
 
     logging.info("Testing ConnectionProfiles class done.\n")

--- a/unit_tests/devicerecords.py
+++ b/unit_tests/devicerecords.py
@@ -13,24 +13,28 @@ def test__devicerecords(fmc):
     starttime = str(int(time.time()))
     namer = f"_fmcapi_test_{starttime}"
 
-    device_records = fmcapi.DeviceRecords(fmc=fmc)
-    resp = device_records.get(expanded=True, includeOtherAssociatedPolicies=True)
-    print(json.dumps(resp, indent=2))
-    # acp1 = fmcapi.AccessPolicies(fmc=fmc, name=namer)
-    # acp1.post()
-    # obj1 = fmcapi.DeviceRecords(fmc=fmc)
-    # obj1.name = namer
-    # obj1.acp(name=acp1.name)
-    # obj1.type = "Device"
-    # obj1.licensing(action="add", name="MALWARE")
-    # obj1.licensing(action="add", name="VPN")
-    # obj1.licensing(action="remove", name="VPN")
-    # obj1.licensing(action="clear")
-    # obj1.licensing(action="add", name="BASE")
-    # obj1.tiering(action="add", name="FTDv5")
-    # logging.info("Device -->")
-    # logging.info(obj1.format_data())
+    all_device_records = fmcapi.DeviceRecords(fmc=fmc)
+    all_device_records.get(expanded=True, includeOtherAssociatedPolicies=True)
+    # Note: attached RAVPN policies output from 'includeOtherAssociatedPolicies=True'
+    # have the INCORRECT UUID. Bug ID: CSCwj27112. This can be worked around for now
+    # by subtracting 1 from the UUID in the response. This has ONLY been observed with
+    # devicerecords api + 'includeOtherAssociatedPolicies=True' + ravpn policies.
 
-    # acp1.delete()
+    acp1 = fmcapi.AccessPolicies(fmc=fmc, name=namer)
+    acp1.post()
+    obj1 = fmcapi.DeviceRecords(fmc=fmc)
+    obj1.name = namer
+    obj1.acp(name=acp1.name)
+    obj1.type = "Device"
+    obj1.licensing(action="add", name="MALWARE")
+    obj1.licensing(action="add", name="VPN")
+    obj1.licensing(action="remove", name="VPN")
+    obj1.licensing(action="clear")
+    obj1.licensing(action="add", name="BASE")
+    obj1.tiering(action="add", name="FTDv5")
+    logging.info("Device -->")
+    logging.info(obj1.format_data())
+
+    acp1.delete()
 
     logging.info("Test Device done.\n")

--- a/unit_tests/devicerecords.py
+++ b/unit_tests/devicerecords.py
@@ -1,6 +1,7 @@
 import logging
 import fmcapi
 import time
+import json
 
 
 def test__devicerecords(fmc):
@@ -12,21 +13,24 @@ def test__devicerecords(fmc):
     starttime = str(int(time.time()))
     namer = f"_fmcapi_test_{starttime}"
 
-    acp1 = fmcapi.AccessPolicies(fmc=fmc, name=namer)
-    acp1.post()
-    obj1 = fmcapi.DeviceRecords(fmc=fmc)
-    obj1.name = namer
-    obj1.acp(name=acp1.name)
-    obj1.type = "Device"
-    obj1.licensing(action="add", name="MALWARE")
-    obj1.licensing(action="add", name="VPN")
-    obj1.licensing(action="remove", name="VPN")
-    obj1.licensing(action="clear")
-    obj1.licensing(action="add", name="BASE")
-    obj1.tiering(action="add", name="FTDv5")
-    logging.info("Device -->")
-    logging.info(obj1.format_data())
+    device_records = fmcapi.DeviceRecords(fmc=fmc)
+    resp = device_records.get(expanded=True, includeOtherAssociatedPolicies=True)
+    print(json.dumps(resp, indent=2))
+    # acp1 = fmcapi.AccessPolicies(fmc=fmc, name=namer)
+    # acp1.post()
+    # obj1 = fmcapi.DeviceRecords(fmc=fmc)
+    # obj1.name = namer
+    # obj1.acp(name=acp1.name)
+    # obj1.type = "Device"
+    # obj1.licensing(action="add", name="MALWARE")
+    # obj1.licensing(action="add", name="VPN")
+    # obj1.licensing(action="remove", name="VPN")
+    # obj1.licensing(action="clear")
+    # obj1.licensing(action="add", name="BASE")
+    # obj1.tiering(action="add", name="FTDv5")
+    # logging.info("Device -->")
+    # logging.info(obj1.format_data())
 
-    acp1.delete()
+    # acp1.delete()
 
     logging.info("Test Device done.\n")

--- a/unit_tests/dynamicaccesspolicies.py
+++ b/unit_tests/dynamicaccesspolicies.py
@@ -1,0 +1,40 @@
+import logging
+import fmcapi
+import time
+import json
+
+def test__dynamicaccesspolicies(fmc):
+    logging.info("Testing DynamicAccessPolicies class.")
+
+    starttime = str(int(time.time()))
+    namer = f"_fmcapi_test_{starttime}"
+
+    dap = fmcapi.DynamicAccessPolicies(fmc=fmc)
+    dap.name = namer
+    dap.post()
+    dap.get()
+
+    dap.authorizationAttributes = [
+        {
+        "dapRecordName": "TEST_DAP_RECORD",
+        "action": "CONTINUE",
+        "message": "TEST_MESSAGE",
+        "priority": 0
+        },
+        {
+        "dapRecordName": "DfltAccessPolicy",
+        "action": "CONTINUE",
+        "priority": -1
+        }
+    ]
+
+    dapXmlConfig_json = '{"dapRecordList":{"dapRecord":{"dapName":{"value":"TEST_DAP_RECORD"},"dapViewsRelation":{"value":"and"},"dapBasicView":{"dapSelection":{"dapPolicy":{"value":"match-any"},"attr":{"name":"aaa.ldap.memberOf","operation":"EQ","value":"test_ad_group"}}}}}}'
+    dap.dapXmlConfig_dict = json.loads(dapXmlConfig_json)
+
+    hostscanXmlConfig_json = '{"data":{"config":{"field":{"_type":"dropdown","_name":"logging","_value":"error"}},"multilocation":{"sequence":{"start":{"location":{"_name":"Default"}}}},"location":{"field":[{"_type":"text","_name":"tWindowsCleanerLogoutTitle","_value":"(WebVPN Logout)"},{"_type":"checkbox","_name":"cWindowsCleanerLogoutTitle","_value":"ON"},{"_type":"dropdown","_name":"dWindowsCleanerTimeout","_value":"5"},{"_type":"dropdown","_name":"dCleanerSecureDeletePass","_value":"3"},{"_type":"dropdown","_name":"dTimeout","_value":"5"},{"_type":"dropdown","_name":"dSDSecureDeletePass","_value":"3"},{"_type":"text","_name":"tRestrictedModeUnRestricted","_value":""},{"_type":"text","_name":"tInternetExplorerHomePage","_value":"about:blank"}],"favorite":{"_type":"folder","_value":"Favorites"},"_name":"Default"},"customization":"","hostscan":"","_version":"3.2.1"}}'
+    dap.hostscanXmlConfig_dict = json.loads(hostscanXmlConfig_json)
+
+    dap.put()
+    dap.delete()
+
+    logging.info("Testing DynamicAccessPolicies class done.\n")

--- a/unit_tests/grouppolicies.py
+++ b/unit_tests/grouppolicies.py
@@ -16,13 +16,16 @@ def test__grouppolicies(fmc):
     group_policy.get()
 
     # Change number of simultaneous ravpn sessions per user as PUT example
+    # Note: simultaneousLoginPerUser = 0 via the api fails to deploy
+    # because of this active bug - CSCwi89739 - even though 0 is a valid value
+    # and can be successfully deployed in the GUI
     sessionSettings = group_policy.advancedSettings.get('sessionSettings')
-    sessionSettings['simultaneousLoginPerUser'] = 0
+    sessionSettings['simultaneousLoginPerUser'] = 1
     group_policy.advancedSettings['sessionSettings'] = sessionSettings
     group_policy.put()
 
     group_policy.get()
-    if group_policy.advancedSettings.get('sessionSettings').get('simultaneousLoginPerUser') == 0:
+    if group_policy.advancedSettings.get('sessionSettings').get('simultaneousLoginPerUser') == 1:
         group_policy.delete()
 
     logging.info("Testing GroupPolicies class done.\n")

--- a/unit_tests/grouppolicies.py
+++ b/unit_tests/grouppolicies.py
@@ -1,0 +1,28 @@
+import logging
+import fmcapi
+import time
+
+def test__grouppolicies(fmc):
+    logging.info("Testing GroupPolicies class.")
+
+    starttime = str(int(time.time()))
+    namer = f"_fmcapi_test_{starttime}"
+
+    group_policy = fmcapi.GroupPolicies(fmc=fmc)
+    group_policy.name = namer
+    # Posting a group policy with just a name will create a blank group policy with whatever defaults the GUI uses at the moment
+    group_policy.post()
+
+    group_policy.get()
+
+    # Change number of simultaneous ravpn sessions per user as PUT example
+    sessionSettings = group_policy.advancedSettings.get('sessionSettings')
+    sessionSettings['simultaneousLoginPerUser'] = 0
+    group_policy.advancedSettings['sessionSettings'] = sessionSettings
+    group_policy.put()
+
+    group_policy.get()
+    if group_policy.advancedSettings.get('sessionSettings').get('simultaneousLoginPerUser') == 0:
+        group_policy.delete()
+
+    logging.info("Testing GroupPolicies class done.\n")

--- a/unit_tests/ravpn.py
+++ b/unit_tests/ravpn.py
@@ -1,0 +1,27 @@
+import logging
+import fmcapi
+import time
+
+def test__ravpn(fmc):
+    logging.info("Testing RAVpn class.")
+
+    starttime = str(int(time.time()))
+    namer = f"_fmcapi_test_{starttime}"
+
+    ravpn_policies = fmcapi.RAVpn(fmc=fmc)
+    logging.info(f'Looking for all RAVPN Policies')
+    all_ravpn_policies = ravpn_policies.get()
+    logging.info(f'Found {len(all_ravpn_policies.get("items"))} RAVPN Policies')
+
+    for policy in all_ravpn_policies.get('items'):
+        ravpn_policy = fmcapi.RAVpn(fmc=fmc)
+        ravpn_policy.id = policy.get('id')
+        ravpn_policy.get(expanded=True)
+        logging.info(f'Found {ravpn_policy.name} with ID of {ravpn_policy.id}')
+
+    # POST, PUT and DELETE are valid endpoints in the api >7.2, however ravpn POST has a cycical dependency
+    # with serveral other api endpoints - connectionprofiles, addressassignments, etc.
+    # This is due to needing a container uuid of the RAVPN policy but also needing those objects to
+    # create the RAVPN policy in the first place.
+
+    logging.info("Testing RAVpn class done.\n")

--- a/unit_tests/ravpn.py
+++ b/unit_tests/ravpn.py
@@ -9,6 +9,7 @@ def test__ravpn(fmc):
     namer = f"_fmcapi_test_{starttime}"
 
     ravpn_policies = fmcapi.RAVpn(fmc=fmc)
+
     logging.info(f'Looking for all RAVPN Policies')
     all_ravpn_policies = ravpn_policies.get()
     logging.info(f'Found {len(all_ravpn_policies.get("items"))} RAVPN Policies')


### PR DESCRIPTION
Added support for:

RAVPN Policies
Group Policies
Connection Profiles
Will add the other child RAVPN policies as my need for them arise. Soon™

Devicerecords updated to work with most of the >7.2 get_filters. 
