### PR TITLE
add xmltodict to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     ],
     keywords="fmcapi fmc ftd security cisco ngfw api firepower",
     packages=find_packages(exclude=["docs", "tests*"]),
-    install_requires=["requests", "datetime", "ipaddress"],
+    install_requires=["requests", "datetime", "ipaddress", "xmltodict"],
     python_requires=">=3.6",
     package_data={},
     data_files=None,


### PR DESCRIPTION
I believe this is needed in order for pip to know that xmltodict is required on a new pip install. #183 
If that is not the case let me know so I know for the future.