### PR TITLE
updated upgradepackage and unit_test workflow as an example of end to end ftd upgrade

### DIFF
--- a/fmcapi/api_objects/deployment_services/deploymentrequests.py
+++ b/fmcapi/api_objects/deployment_services/deploymentrequests.py
@@ -63,7 +63,7 @@ class DeploymentRequests(
         response = self.fmc.send_to_api(
             method="post", url=self.URL, json_data=json_data
         )
-        return response["deviceList"]
+        return response
 
     def put(self):
         """PUT method for API for DeploymentRequests not supported."""

--- a/fmcapi/api_objects/update_packages/upgradepackage.py
+++ b/fmcapi/api_objects/update_packages/upgradepackage.py
@@ -21,6 +21,13 @@ class Upgrades(APIClassTemplate):
         "upgradePackage",
         "targets",
         "pushUpgradeFileOnly",
+        "readinessCheckOnly",
+        "enableUpgradeRevert",
+        "autoUpgradeCancel",
+    ]
+    REQUIRED_FOR_POST = [
+        "upgradePackage",
+        "targets"
     ]
     VALID_FOR_KWARGS = VALID_JSON_DATA + []
     URL_SUFFIX = "/updates/upgrades"

--- a/unit_tests/upgrades.py
+++ b/unit_tests/upgrades.py
@@ -1,16 +1,25 @@
 import logging
 import fmcapi
 import time
-from unit_tests import wait_for_task
+from .wait_for_task import wait_for_task
 
 
 def test__upgrades(fmc):
     logging.info(
-        "Test UpgradePackages/ApplicableDevices/Upgrades with Task."
-        "  This will copy the listed upgrade file to registered devices"
+        """Test UpgradePackages/ApplicableDevices/Upgrades with Task.
+        This will copy the listed upgrade file to registered devices
+
+        Commented lines at the bottom show how to trigger readiness check, the actual upgrade process,
+        and the post upgrade deployment.
+
+        NOTE: this script will do this to ALL applicable devices based on the package_name given.
+            example: you have 5 FTDvs and you only want to upgrade 2 of them. Input here is just the package_name.
+            Script will add all eligible devices for the particular file given to the list of devices to run against.
+            Potentially resulting in upgrading all 5 FTDv unintentionally.
+        """
     )
 
-    package_name = "Cisco_FTD_Patch-6.3.0.3-77.sh.REL.tar"
+    package_name = "Cisco_FTD_Patch-7.4.1.1-12.sh.REL.tar"
     device_list = []
 
     logging.info("All UpgradePackages -- >")
@@ -37,8 +46,32 @@ def test__upgrades(fmc):
     upgrades1.upgrade_package(package_name=package_name)
     upgrades1.pushUpgradeFileOnly = True
 
+    logging.info(f"Pushing upgrade file to {device_list}")
     response = upgrades1.post()
     logging.info(response)
     wait_for_task(fmc=fmc, task=response["metadata"]["task"], wait_time=60)
+
+    # BELOW ARE EXAMPLES OF HOW TO TRIGGER READINESS CHECKS AND ACTUAL UPGRADES
+    # THIS INCLUDES REBOOTS AND DEPLOYMENTS.
+
+    # upgrades1.pushUpgradeFileOnly = False
+    # upgrades1.readinessCheckOnly = True
+
+    # logging.info(f"Triggering readiness checks on {device_list}")
+    # response = upgrades1.post()
+    # logging.info(response)
+    # wait_for_task(fmc=fmc, task=response["metadata"]["task"], wait_time=60)
+
+    # upgrades1.readinessCheckOnly = False
+
+    # logging.info(f"Triggering REAL UPGRADE on {device_list}")
+    # response = upgrades1.post()
+    # logging.info(response)
+    # wait_for_task(fmc=fmc, task=response["metadata"]["task"], wait_time=60)
+
+    # logging.info(f"Upgrade completed. Triggering deployment to devices")
+    # deployment = fmcapi.DeploymentRequests(fmc=fmc)
+    # logging.info(deployment)
+    # wait_for_task(fmc=fmc, task=deployment["metadata"]["task"], wait_time=60)
 
     logging.info("Test UpgradePackages/ApplicableDevices/Upgrades Complete")

--- a/unit_tests/upgrades.py
+++ b/unit_tests/upgrades.py
@@ -71,7 +71,8 @@ def test__upgrades(fmc):
 
     # logging.info(f"Upgrade completed. Triggering deployment to devices")
     # deployment = fmcapi.DeploymentRequests(fmc=fmc)
-    # logging.info(deployment)
-    # wait_for_task(fmc=fmc, task=deployment["metadata"]["task"], wait_time=60)
+    # response = deployment.post()
+    # logging.info(response)
+    # wait_for_task(fmc=fmc, task=response["metadata"]["task"], wait_time=60)
 
     logging.info("Test UpgradePackages/ApplicableDevices/Upgrades Complete")

--- a/unit_tests/wait_for_task.py
+++ b/unit_tests/wait_for_task.py
@@ -4,7 +4,7 @@ import logging
 
 
 def wait_for_task(fmc, task, wait_time=10):
-    task_completed_states = ["Success", "SUCCESS", "COMPLETED"]
+    task_completed_states = ["Success", "SUCCESS", "COMPLETED", "Deployed"]
     try:
         status = fmcapi.TaskStatuses(fmc=fmc, id=task["id"])
         current_status = status.get()


### PR DESCRIPTION
updated upgradepackage to include the ability to trigger readiness checks and other newer flags in that api endpoint (based on fmc 7.4.1.1)

upgrade unit_test workflow now has an example of end to end ftd upgrade (push file, readiness check, upgrade, post upgrade deployment)

`fmcapi/api_objects/deployment_services/deploymentrequests.py` was modified and may break some code in the wild with this modification. 

Instead of returning just the device list in the deployment response, it made more sense to me to return the entire response and then pull the device list out outside of the object code. This also means that deploymentrequest now works and fits better with the existing `wait_for_task` unit_test