### PR TITLE
Fixed adding null0 static routes

### DIFF
--- a/fmcapi/api_objects/device_services/ipv4staticroutes.py
+++ b/fmcapi/api_objects/device_services/ipv4staticroutes.py
@@ -196,3 +196,16 @@ class IPv4StaticRoutes(APIClassTemplate):
             logging.warning(
                 f"Object {name} not found.  Cannot set up device for IPv4StaticRoute."
             )
+
+    def post(self, **kwargs):
+        """
+        Modified post method for ipv4staticroutes
+        """
+        logging.debug("In post() for IPv4StaticRoute class.")
+        # Handle Null0 routes not needing a gateway
+        if self.interfaceName:
+            if self.interfaceName == "Null0" or self.interfaceName == "null0":
+                # Remove gateway from REQUIRED_FOR_POST global const
+                self.REQUIRED_FOR_POST = ["interfaceName", "selectedNetworks"]
+        response = super().post(**kwargs)
+        return response

--- a/fmcapi/api_objects/device_services/ipv6staticroutes.py
+++ b/fmcapi/api_objects/device_services/ipv6staticroutes.py
@@ -174,3 +174,16 @@ class IPv6StaticRoutes(APIClassTemplate):
             logging.warning(
                 f'Network "{name}" not found.  Cannot set up device for IPv6StaticRoute.'
             )
+
+    def post(self, **kwargs):
+        """
+        Modified post method for ipv6staticroutes
+        """
+        logging.debug("In post() for IPv6StaticRoute class.")
+        # Handle Null0 routes not needing a gateway
+        if self.interfaceName:
+            if self.interfaceName == "Null0" or self.interfaceName == "null0":
+                # Remove gateway from REQUIRED_FOR_POST global const
+                self.REQUIRED_FOR_POST = ["interfaceName", "selectedNetworks"]
+        response = super().post(**kwargs)
+        return response

--- a/unit_tests/ipv4staticroutes.py
+++ b/unit_tests/ipv4staticroutes.py
@@ -21,13 +21,14 @@ def test__ipv4staticroutes(fmc):
     ipv4route1 = fmcapi.IPv4StaticRoutes(fmc=fmc, name="_ipv4route1")
     ipv4route1.device(device_name="ftdv01.ccie.lab")
     ipv4route1.networks(action="add", networks=[ipnet1.name, ipnet2.name])
+    # NO GATEWAY IS EXPECTED WHEN IMPLEMENTING A ROUTE VIA NULL0
     ipv4route1.gw(name=iphost1.name)
     ipv4route1.interfaceName = "ifname"
     ipv4route1.metricValue = 1
     result = ipv4route1.post()
 
     ipv4route2 = fmcapi.IPv4StaticRoutes(fmc=fmc, name="_ipv4route1")
-    ipv4route2.device(device_name="device_name")
+    ipv4route2.device(device_name="ftdv01.ccie.lab")
     ipv4route2.id = result["id"]
     ipv4route2.get()
 

--- a/unit_tests/ipv6staticroutes.py
+++ b/unit_tests/ipv6staticroutes.py
@@ -18,24 +18,25 @@ def test__ipv6staticroutes(fmc):
     ipnet1.post()
     ipnet2.post()
 
-    ipv4route1 = fmcapi.IPv6StaticRoutes(fmc=fmc, name="_ipv6route1")
-    ipv4route1.device(device_name="ftdv01.ccie.lab")
-    ipv4route1.networks(action="add", networks=[ipnet1.name, ipnet2.name])
-    ipv4route1.gw(name=iphost1.name)
-    ipv4route1.interfaceName = "ifname"
-    ipv4route1.metricValue = 1
-    result = ipv4route1.post()
+    ipv6route1 = fmcapi.IPv6StaticRoutes(fmc=fmc, name="_ipv6route1")
+    ipv6route1.device(device_name="ftdv01.ccie.lab")
+    ipv6route1.networks(action="add", networks=[ipnet1.name, ipnet2.name])
+    # NO GATEWAY IS EXPECTED WHEN IMPLEMENTING A ROUTE VIA NULL0
+    ipv6route1.gw(name=iphost1.name)
+    ipv6route1.interfaceName = "ifname"
+    ipv6route1.metricValue = 1
+    result = ipv6route1.post()
 
-    ipv4route2 = fmcapi.IPv4StaticRoutes(fmc=fmc, name="_ipv6route1")
-    ipv4route2.device(device_name="device_name")
-    ipv4route2.id = result["id"]
-    ipv4route2.get()
+    ipv6route2 = fmcapi.IPv6StaticRoutes(fmc=fmc, name="_ipv6route1")
+    ipv6route2.device(device_name="ftdv01.ccie.lab")
+    ipv6route2.id = result["id"]
+    ipv6route2.get()
 
-    del ipv4route1
-    ipv4route2.networks(action="remove", networks=[ipnet2.name])
-    ipv4route2.put()
+    del ipv6route1
+    ipv6route2.networks(action="remove", networks=[ipnet2.name])
+    ipv6route2.put()
 
-    ipv4route2.delete()
+    ipv6route2.delete()
     ipnet1.delete()
     ipnet2.delete()
     iphost1.delete()


### PR DESCRIPTION
When adding a Null0 static route, no gateway is expected, but the class was requiring `self.gateway` for posts. 
Added a fix for this by removing gateway from `REQUIRED_FOR_POST` only when the interface is Null0.

This should take care of the current concern in #194 

Also updated the ipv6staticroute unit_test to do all ipv6 routes :)