### PR TITLE
Bulk network object post and delete

### DIFF
--- a/fmcapi/api_objects/apiclasstemplate.py
+++ b/fmcapi/api_objects/apiclasstemplate.py
@@ -564,12 +564,17 @@ class APIClassTemplate(object):
             )
             return False
         if self.valid_for_bulk_post():
+            self.bulk_ids = []
             if len(self.bulk) > 0:
                 if len(self.bulk) > 49:
                     self.chunks = bulk_list_splitter(self.bulk)
                     for chunk in self.chunks:
                         self.bulk_post_data = chunk
-                        APIClassTemplate.post(self)
+                        response = APIClassTemplate.post(self)
+                        for i in response['items']:
+                            self.bulk_ids.append(i['id'])
                 else:
-                    self.bulk_post_data = self.bulk_post
-                    APIClassTemplate.post(self)
+                    self.bulk_post_data = self.bulk
+                    response = APIClassTemplate.post(self)
+                    for i in response['items']:
+                            self.bulk_ids.append(i['id'])

--- a/fmcapi/api_objects/apiclasstemplate.py
+++ b/fmcapi/api_objects/apiclasstemplate.py
@@ -1,5 +1,5 @@
 """Super class(es) that is inherited by all API objects."""
-from .helper_functions import syntax_correcter
+from .helper_functions import syntax_correcter, bulk_list_splitter, check_uuid
 import logging
 import json
 
@@ -14,6 +14,8 @@ class APIClassTemplate(object):
     REQUIRED_FOR_DELETE = ["id"]
     REQUIRED_FOR_GET = [""]
     REQUIRED_GET_FILTERS = []
+    REQUIRED_FOR_BULK_POST = ["bulk"]
+    REQUIRED_FOR_BULK_DELETE = ["bulk"]
     FILTER_BY_NAME = False
     URL = ""
     URL_SUFFIX = ""
@@ -277,6 +279,17 @@ class APIClassTemplate(object):
         :return: (boolean)
         """
         logging.debug("In valid_for_post() for APIClassTemplate class.")
+        if "bulk_post_data" in  self.__dict__:
+            missing_required_item = False
+            # Check within each payload to ensure required for post is handled
+            for i in self.bulk_post_data:
+                for item in self.REQUIRED_FOR_POST:
+                    if item not in i:
+                        logging.error(f'BULK POST FAILED: Missing value "{item}" in {i}')
+                        missing_required_item = True
+            if missing_required_item:
+                return False
+            return True
         for item in self.REQUIRED_FOR_POST:
             if item not in self.__dict__:
                 logging.error(f'Missing value "{item}" for POST request.')
@@ -303,23 +316,35 @@ class APIClassTemplate(object):
             self.put()
         else:
             if self.valid_for_post():
+                if "bulk_post_data" in self.__dict__:
+                    url = f"{self.URL}?bulk=true"
+                else:
+                    url = f"{self.URL}"
                 if self.dry_run:
                     logging.info(
                         "Dry Run enabled.  Not actually sending to FMC.  Here is what would have been sent:"
                     )
                     logging.info("\tMethod = POST")
-                    logging.info(f"\tURL = {self.URL}")
+                    logging.info(f"\tURL = {url}")
                     logging.info(f"\tJSON = {self.show_json}")
                     return False
-                response = self.fmc.send_to_api(
-                    method="post", url=self.URL, json_data=self.format_data()
-                )
+                if "bulk_post_data" in self.__dict__:
+                    response = self.fmc.send_to_api(
+                        method="post", url=url, json_data=self.bulk_post_data
+                    )
+                else:
+                    response = self.fmc.send_to_api(
+                        method="post", url=url, json_data=self.format_data()
+                    )
                 if response:
                     self.parse_kwargs(**response)
                     if "name" in self.__dict__ and "id" in self.__dict__:
                         logging.info(
                             f'POST success. Object with name: "{self.name}" and id: "{self.id}" created in FMC.'
                         )
+                    elif "bulk_post_data" in self.__dict__:
+                        logging.info(f'BULK POST success. Items bulk posted: {len(response["items"])}')
+                        logging.debug(f'BULK POST: {response["items"]}')
                     else:
                         logging.debug(
                             'POST success but no "id" or "name" values in API response.'
@@ -395,6 +420,15 @@ class APIClassTemplate(object):
         :return: (boolean)
         """
         logging.debug("In valid_for_delete() for APIClassTemplate class.")
+        if "bulk_delete_data" in self.__dict__:
+            # Validate bulk delete data is a list of valid ids
+            valid = True
+            for i in self.bulk_delete_data:
+                if not check_uuid(i):
+                    valid = False
+            if not valid:
+                return False
+            return True
         for item in self.REQUIRED_FOR_DELETE:
             if item not in self.__dict__:
                 logging.error(f'Missing value "{item}" for DELETE request.')
@@ -419,6 +453,10 @@ class APIClassTemplate(object):
                 url = f"{self.URL}/{self.targetId}"
                 if "backupVersion" in self.__dict__:
                     url += f"?backupVersion={self.backupVersion}"
+            elif "bulk_delete_data" in self.__dict__:
+                # Convert bulk delete data to csv string to insert into url
+                self.bulk_delete_str = ','.join(map(str,self.bulk_delete_data))
+                url = f"{self.URL}?filter=ids:{self.bulk_delete_str}&bulk=true"
             else:
                 url = f"{self.URL}/{self.id}"
             if self.dry_run:
@@ -448,6 +486,9 @@ class APIClassTemplate(object):
                     logging.info(
                         f'DELETE success. Object with targetId: "{self.targetId}" deleted from FMC.'
                     )
+            elif "bulk_delete_data" in self.__dict__:
+                logging.info(f'Bulk DELETE success. Objects deleted in FMC: {len(self.bulk_delete_data)}')
+                logging.debug(f'Bulk DELETE: {self.bulk_delete_data}')
             else:
                 logging.info(f'DELETE success. Object id: "{self.id}" deleted in FMC.')
             return response
@@ -456,3 +497,79 @@ class APIClassTemplate(object):
                 "delete() method failed due to failure to pass valid_for_delete() test."
             )
             return False
+
+    def valid_for_bulk_delete(self):
+        """
+        Use REQUIRED_FOR_BULK_DELETE to ensure all necessary variables exist prior to submitting to API.
+
+        :return: (boolean)
+        """
+        logging.debug("In valid_for_bulk_delete() for APIClassTemplate class.")
+
+        for item in self.REQUIRED_FOR_BULK_DELETE:
+            if item not in self.__dict__:
+                logging.error(f'Missing value "{item}" for bulk DELETE request.')
+                return False
+        return True
+
+    def bulk_delete(self, **kwargs):
+        """
+        This is a shim in front of the normal delete() to handle bulk deletes.
+
+        """
+        logging.debug("In bulk_delete() for APIClassTemplate class.")
+        self.parse_kwargs(**kwargs)
+        if self.fmc.serverVersion < self.FIRST_SUPPORTED_FMC_VERSION:
+            logging.error(
+                f"Your FMC version, {self.fmc.serverVersion} does not support bulk DELETE of this feature."
+            )
+            return False
+        if self.valid_for_bulk_delete():
+            if len(self.bulk) > 0:
+                if len(self.bulk) > 49:
+                    self.chunks = bulk_list_splitter(self.bulk)
+                    for chunk in self.chunks:
+                        self.bulk_delete_data = chunk
+                        # self.ids_str = ','.join(map(str,self.ids))
+                        APIClassTemplate.delete(self)
+                else:
+                    self.bulk_delete_data = self.bulk
+                    # self.ids_str = ','.join(map(str,self.ids))
+                    APIClassTemplate.delete(self)
+
+    def valid_for_bulk_post(self):
+        """
+        Use REQUIRED_FOR_BULK_POST to ensure all necessary variables exist prior to submitting to API.
+
+        :return: (boolean)
+        """
+        logging.debug("In valid_for_bulk_post() for APIClassTemplate class.")
+
+        for item in self.REQUIRED_FOR_BULK_POST:
+            if item not in self.__dict__:
+                logging.error(f'Missing value "{item}" for bulk POST request.')
+                return False
+        return True
+
+    def bulk_post(self, **kwargs):
+        """
+        This is a shim in front of the normal post() to handle bulk posts.
+
+        """
+        logging.debug("In bulk_post() for APIClassTemplate class.")
+        self.parse_kwargs(**kwargs)
+        if self.fmc.serverVersion < self.FIRST_SUPPORTED_FMC_VERSION:
+            logging.error(
+                f"Your FMC version, {self.fmc.serverVersion} does not support bulk POST of this feature."
+            )
+            return False
+        if self.valid_for_bulk_post():
+            if len(self.bulk) > 0:
+                if len(self.bulk) > 49:
+                    self.chunks = bulk_list_splitter(self.bulk)
+                    for chunk in self.chunks:
+                        self.bulk_post_data = chunk
+                        APIClassTemplate.post(self)
+                else:
+                    self.bulk_post_data = self.bulk_post
+                    APIClassTemplate.post(self)

--- a/fmcapi/api_objects/helper_functions.py
+++ b/fmcapi/api_objects/helper_functions.py
@@ -4,6 +4,8 @@ import re
 import ipaddress
 import json
 import logging
+import uuid
+
 
 logging.debug(f"In the {__name__} module.")
 
@@ -166,3 +168,27 @@ def validate_vlans(start_vlan, end_vlan=""):
         return start_vlan, end_vlan
     else:
         return 1, 4094
+
+
+def bulk_list_splitter(ids, chunk_size=49):
+    """_summary_
+
+    Args:
+        ids (list): list of ids used in bulk post/delete operations
+        chunk_size (int, optional): bulk operations seem to be limited to 49 max ids in one url. Defaults to 49.
+
+    Returns:
+        list: list of lists where each inner list is 49 items
+    """
+    chunks = []
+    for id in range(0, len(ids), chunk_size):
+        chunks.append(ids[id:id + chunk_size])
+    return chunks
+
+def check_uuid(uuid_input):
+    try:
+        uuid.UUID(str(uuid_input))
+        return True
+    except ValueError:
+        return False
+

--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -78,6 +78,7 @@ from .ravpn import test__ravpn
 from .connectionprofiles import test__connectionprofiles
 from .dynamicaccesspolicies import test__dynamicaccesspolicies
 from .timeranges import test__timeranges
+from .fqdns import test__fqdns
 
 logging.debug("In the unit-tests __init__.py file.")
 
@@ -160,4 +161,5 @@ __all__ = [
     "test__connectionprofiles",
     "test__dynamicaccesspolicies",
     "test__timeranges",
+    "test__fqdns"
 ]

--- a/unit_tests/fqdns.py
+++ b/unit_tests/fqdns.py
@@ -24,6 +24,21 @@ def test__fqdns(fmc):
 
     obj = fmcapi.FQDNS(fmc=fmc)
     obj.bulk = []
+    for i in range(10):
+        obj.bulk.append(
+            {
+                "name" : f"_fmcapi_test_{id_generator()}",
+                "value" : "www.cisco.com",
+                "dnsResolution" : "IPV4_ONLY"
+            }
+        )
+    obj.bulk_post()
+    obj.bulk = obj.bulk_ids
+    obj.bulk_delete()
+    del obj
+
+    obj = fmcapi.FQDNS(fmc=fmc)
+    obj.bulk = []
     for i in range(50):
         obj.bulk.append(
             {
@@ -33,22 +48,8 @@ def test__fqdns(fmc):
             }
         )
     obj.bulk_post()
-
-    # sleep a bit otherwise the api just doesn't know that these objects are unused immediately after post
-    time.sleep(10)
-
-    ids = []
-    fqdn_obs = fmcapi.FQDNS(fmc=fmc)
-    # getting unused fqdn & ranges objects from fmc api is broken in 7.6
-    unused_fqdn = fqdn_obs.get(unusedOnly=True)
-    if 'items' in unused_fqdn:
-        for obj in unused_fqdn['items']:
-            ids.append(obj['id'])
-
-        bulk_delete = fmcapi.FQDNS(fmc=fmc)
-        bulk_delete.bulk = ids
-        bulk_delete.bulk_delete()
-    else:
-        logging.info(f'No unused objects to bulk delete')
+    obj.bulk = obj.bulk_ids
+    obj.bulk_delete()
+    del obj
 
     logging.info("FQDNS DNSServerGroups class done.\n")

--- a/unit_tests/fqdns.py
+++ b/unit_tests/fqdns.py
@@ -1,5 +1,7 @@
 import logging
 import fmcapi
+import time
+from .helper_functions import id_generator
 
 
 def test__fqdns(fmc):
@@ -19,5 +21,34 @@ def test__fqdns(fmc):
     obj1.put()
 
     obj1.delete()
+
+    obj = fmcapi.FQDNS(fmc=fmc)
+    obj.bulk = []
+    for i in range(50):
+        obj.bulk.append(
+            {
+                "name" : f"_fmcapi_test_{id_generator()}",
+                "value" : "www.cisco.com",
+                "dnsResolution" : "IPV4_ONLY"
+            }
+        )
+    obj.bulk_post()
+
+    # sleep a bit otherwise the api just doesn't know that these objects are unused immediately after post
+    time.sleep(10)
+
+    ids = []
+    fqdn_obs = fmcapi.FQDNS(fmc=fmc)
+    # getting unused fqdn & ranges objects from fmc api is broken in 7.6
+    unused_fqdn = fqdn_obs.get(unusedOnly=True)
+    if 'items' in unused_fqdn:
+        for obj in unused_fqdn['items']:
+            ids.append(obj['id'])
+
+        bulk_delete = fmcapi.FQDNS(fmc=fmc)
+        bulk_delete.bulk = ids
+        bulk_delete.bulk_delete()
+    else:
+        logging.info(f'No unused objects to bulk delete')
 
     logging.info("FQDNS DNSServerGroups class done.\n")

--- a/unit_tests/ip_host.py
+++ b/unit_tests/ip_host.py
@@ -26,6 +26,20 @@ def test__ip_host(fmc):
 
     obj = fmcapi.Hosts(fmc=fmc)
     obj.bulk = []
+    for i in range(5):
+        obj.bulk.append(
+            {
+                "name" : f"_fmcapi_test_{id_generator()}",
+                "value" : "9.9.9.9"
+            }
+        )
+    obj.bulk_post()
+    obj.bulk = obj.bulk_ids
+    obj.bulk_delete()
+    del obj
+
+    obj = fmcapi.Hosts(fmc=fmc)
+    obj.bulk = []
     for i in range(50):
         obj.bulk.append(
             {
@@ -34,21 +48,8 @@ def test__ip_host(fmc):
             }
         )
     obj.bulk_post()
-
-    # sleep a bit otherwise the api just doesn't know that these objects are unused immediately after post
-    time.sleep(10)
-
-    ids = []
-    host_obs = fmcapi.Hosts(fmc=fmc)
-    unused_hosts = host_obs.get(unusedOnly=True)
-    if 'items' in unused_hosts:
-        for host in unused_hosts['items']:
-            ids.append(host['id'])
-
-        bulk_delete = fmcapi.Hosts(fmc=fmc)
-        bulk_delete.bulk = ids
-        bulk_delete.bulk_delete()
-    else:
-        logging.info(f'No unused objects to bulk delete')
+    obj.bulk = obj.bulk_ids
+    obj.bulk_delete()
+    del obj
 
     logging.info("Test IPHost done.\n")

--- a/unit_tests/ip_host.py
+++ b/unit_tests/ip_host.py
@@ -1,7 +1,7 @@
 import logging
 import fmcapi
 import time
-
+from .helper_functions import id_generator
 
 def test__ip_host(fmc):
     logging.info("Test IPHost.  Post, get, put, delete Host Objects.")
@@ -15,11 +15,40 @@ def test__ip_host(fmc):
     obj1.post()
     time.sleep(1)
     del obj1
+
     obj1 = fmcapi.Hosts(fmc=fmc, name=namer)
     obj1.get()
     obj1.value = "9.9.9.9"
     obj1.put()
     time.sleep(1)
     obj1.delete()
+    del obj1
+
+    obj = fmcapi.Hosts(fmc=fmc)
+    obj.bulk = []
+    for i in range(50):
+        obj.bulk.append(
+            {
+                "name" : f"_fmcapi_test_{id_generator()}",
+                "value" : "9.9.9.9"
+            }
+        )
+    obj.bulk_post()
+
+    # sleep a bit otherwise the api just doesn't know that these objects are unused immediately after post
+    time.sleep(10)
+
+    ids = []
+    host_obs = fmcapi.Hosts(fmc=fmc)
+    unused_hosts = host_obs.get(unusedOnly=True)
+    if 'items' in unused_hosts:
+        for host in unused_hosts['items']:
+            ids.append(host['id'])
+
+        bulk_delete = fmcapi.Hosts(fmc=fmc)
+        bulk_delete.bulk = ids
+        bulk_delete.bulk_delete()
+    else:
+        logging.info(f'No unused objects to bulk delete')
 
     logging.info("Test IPHost done.\n")

--- a/unit_tests/ip_network.py
+++ b/unit_tests/ip_network.py
@@ -25,6 +25,20 @@ def test__ip_network(fmc):
 
     obj = fmcapi.Networks(fmc=fmc)
     obj.bulk = []
+    for i in range(15):
+        obj.bulk.append(
+            {
+                "name" : f"_fmcapi_test_{id_generator()}",
+                "value" : "9.9.9.0/24"
+            }
+        )
+    obj.bulk_post()
+    obj.bulk = obj.bulk_ids
+    obj.bulk_delete()
+    del obj
+
+    obj = fmcapi.Networks(fmc=fmc)
+    obj.bulk = []
     for i in range(50):
         obj.bulk.append(
             {
@@ -33,26 +47,8 @@ def test__ip_network(fmc):
             }
         )
     obj.bulk_post()
-
-    # sleep a bit otherwise the api just doesn't know that these objects are unused immediately after post
-    time.sleep(10)
-
-    ids = []
-    network_obs = fmcapi.Networks(fmc=fmc)
-    network_obs.expanded=True
-    unused_networks = network_obs.get(unusedOnly=True)
-    if 'items' in unused_networks:
-        for obj in unused_networks['items']:
-            # Do not try and modify/delete system defined/readonly objects (ex. default RFC1918 object)
-            if 'readOnly' not in obj['metadata']:
-                ids.append(obj['id'])
-            else:
-                logging.info(f"{obj['id']} is a system defined read only object that happens to be unused. This will not be removed!")
-
-        bulk_delete = fmcapi.Networks(fmc=fmc)
-        bulk_delete.bulk = ids
-        bulk_delete.bulk_delete()
-    else:
-        logging.info(f'No unused objects to bulk delete')
+    obj.bulk = obj.bulk_ids
+    obj.bulk_delete()
+    del obj
 
     logging.info("Test IPNetwork done.\n")

--- a/unit_tests/ip_network.py
+++ b/unit_tests/ip_network.py
@@ -1,7 +1,7 @@
 import logging
 import fmcapi
 import time
-
+from .helper_functions import id_generator
 
 def test__ip_network(fmc):
     logging.info("Test IPNetwork.  Post, get, put, delete Network Objects.")
@@ -22,5 +22,37 @@ def test__ip_network(fmc):
     obj1.put()
     time.sleep(1)
     obj1.delete()
+
+    obj = fmcapi.Networks(fmc=fmc)
+    obj.bulk = []
+    for i in range(50):
+        obj.bulk.append(
+            {
+                "name" : f"_fmcapi_test_{id_generator()}",
+                "value" : "9.9.9.0/24"
+            }
+        )
+    obj.bulk_post()
+
+    # sleep a bit otherwise the api just doesn't know that these objects are unused immediately after post
+    time.sleep(10)
+
+    ids = []
+    network_obs = fmcapi.Networks(fmc=fmc)
+    network_obs.expanded=True
+    unused_networks = network_obs.get(unusedOnly=True)
+    if 'items' in unused_networks:
+        for obj in unused_networks['items']:
+            # Do not try and modify/delete system defined/readonly objects (ex. default RFC1918 object)
+            if 'readOnly' not in obj['metadata']:
+                ids.append(obj['id'])
+            else:
+                logging.info(f"{obj['id']} is a system defined read only object that happens to be unused. This will not be removed!")
+
+        bulk_delete = fmcapi.Networks(fmc=fmc)
+        bulk_delete.bulk = ids
+        bulk_delete.bulk_delete()
+    else:
+        logging.info(f'No unused objects to bulk delete')
 
     logging.info("Test IPNetwork done.\n")

--- a/unit_tests/ip_range.py
+++ b/unit_tests/ip_range.py
@@ -1,6 +1,7 @@
 import logging
 import fmcapi
 import time
+from .helper_functions import id_generator
 
 
 def test__ip_range(fmc):
@@ -22,5 +23,32 @@ def test__ip_range(fmc):
     obj1.put()
     time.sleep(1)
     obj1.delete()
+
+    obj = fmcapi.Ranges(fmc=fmc)
+    obj.bulk = []
+    for i in range(50):
+        obj.bulk.append(
+            {
+                "name" : f"_fmcapi_test_{id_generator()}",
+                "value" : "3.3.3.3-4.4.4.4"
+            }
+        )
+    obj.bulk_post()
+
+    # sleep a bit otherwise the api just doesn't know that these objects are unused immediately after post
+    time.sleep(10)
+
+    ids = []
+    range_obs = fmcapi.Ranges(fmc=fmc)
+    unused_ranges = range_obs.get(unusedOnly=True)
+    if 'items' in unused_ranges:
+        for i in unused_ranges['items']:
+            ids.append(i['id'])
+
+        bulk_delete = fmcapi.Ranges(fmc=fmc)
+        bulk_delete.bulk = ids
+        bulk_delete.bulk_delete()
+    else:
+        logging.info(f'No unused objects to bulk delete')
 
     logging.info("Test IPRange done.\n")

--- a/unit_tests/ip_range.py
+++ b/unit_tests/ip_range.py
@@ -26,6 +26,20 @@ def test__ip_range(fmc):
 
     obj = fmcapi.Ranges(fmc=fmc)
     obj.bulk = []
+    for i in range(13):
+        obj.bulk.append(
+            {
+                "name" : f"_fmcapi_test_{id_generator()}",
+                "value" : "3.3.3.3-4.4.4.4"
+            }
+        )
+    obj.bulk_post()
+    obj.bulk = obj.bulk_ids
+    obj.bulk_delete()
+    del obj
+
+    obj = fmcapi.Ranges(fmc=fmc)
+    obj.bulk = []
     for i in range(50):
         obj.bulk.append(
             {
@@ -34,21 +48,8 @@ def test__ip_range(fmc):
             }
         )
     obj.bulk_post()
-
-    # sleep a bit otherwise the api just doesn't know that these objects are unused immediately after post
-    time.sleep(10)
-
-    ids = []
-    range_obs = fmcapi.Ranges(fmc=fmc)
-    unused_ranges = range_obs.get(unusedOnly=True)
-    if 'items' in unused_ranges:
-        for i in unused_ranges['items']:
-            ids.append(i['id'])
-
-        bulk_delete = fmcapi.Ranges(fmc=fmc)
-        bulk_delete.bulk = ids
-        bulk_delete.bulk_delete()
-    else:
-        logging.info(f'No unused objects to bulk delete')
+    obj.bulk = obj.bulk_ids
+    obj.bulk_delete()
+    del obj
 
     logging.info("Test IPRange done.\n")

--- a/unit_tests/protocol_port.py
+++ b/unit_tests/protocol_port.py
@@ -25,6 +25,20 @@ def test__protocol_port(fmc):
     time.sleep(1)
     obj1.delete()
 
+    obj = fmcapi.ProtocolPortObjects(fmc=fmc)
+    obj.bulk = []
+    for i in range(12):
+        obj.bulk.append(
+            {
+                "name" : f"_fmcapi_test_{id_generator()}",
+                "protocol" : "TCP",
+                "port" : "5678"
+            }
+        )
+    obj.bulk_post()
+    obj.bulk = obj.bulk_ids
+    obj.bulk_delete()
+    del obj
 
     obj = fmcapi.ProtocolPortObjects(fmc=fmc)
     obj.bulk = []
@@ -37,26 +51,8 @@ def test__protocol_port(fmc):
             }
         )
     obj.bulk_post()
-
-    # sleep a bit otherwise the api just doesn't know that these objects are unused immediately after post
-    time.sleep(10)
-
-    ids = []
-    protocol_port_obs = fmcapi.ProtocolPortObjects(fmc=fmc)
-    protocol_port_obs.expanded=True
-    unused_protocol_ports = protocol_port_obs.get(unusedOnly=True)
-    if 'items' in unused_protocol_ports:
-        for obj in unused_protocol_ports['items']:
-            # Do not try and modify/delete system defined/readonly objects (ex. default RFC1918 object)
-            if 'readOnly' not in obj['metadata']:
-                ids.append(obj['id'])
-            else:
-                logging.info(f"{obj['id']} is a system defined read only object that happens to be unused. This will not be removed!")
-
-        bulk_delete = fmcapi.Networks(fmc=fmc)
-        bulk_delete.bulk = ids
-        bulk_delete.bulk_delete()
-    else:
-        logging.info(f'No unused objects to bulk delete')
+    obj.bulk = obj.bulk_ids
+    obj.bulk_delete()
+    del obj
 
     logging.info("Test ProtocolPort done.\n")

--- a/unit_tests/protocol_port.py
+++ b/unit_tests/protocol_port.py
@@ -1,6 +1,7 @@
 import logging
 import fmcapi
 import time
+from .helper_functions import id_generator
 
 
 def test__protocol_port(fmc):
@@ -16,10 +17,46 @@ def test__protocol_port(fmc):
     obj1.post()
     time.sleep(1)
     del obj1
+
     obj1 = fmcapi.ProtocolPortObjects(fmc=fmc, name=namer)
     obj1.get()
     obj1.port = "5678"
     obj1.put()
     time.sleep(1)
     obj1.delete()
+
+
+    obj = fmcapi.ProtocolPortObjects(fmc=fmc)
+    obj.bulk = []
+    for i in range(50):
+        obj.bulk.append(
+            {
+                "name" : f"_fmcapi_test_{id_generator()}",
+                "protocol" : "TCP",
+                "port" : "5678"
+            }
+        )
+    obj.bulk_post()
+
+    # sleep a bit otherwise the api just doesn't know that these objects are unused immediately after post
+    time.sleep(10)
+
+    ids = []
+    protocol_port_obs = fmcapi.ProtocolPortObjects(fmc=fmc)
+    protocol_port_obs.expanded=True
+    unused_protocol_ports = protocol_port_obs.get(unusedOnly=True)
+    if 'items' in unused_protocol_ports:
+        for obj in unused_protocol_ports['items']:
+            # Do not try and modify/delete system defined/readonly objects (ex. default RFC1918 object)
+            if 'readOnly' not in obj['metadata']:
+                ids.append(obj['id'])
+            else:
+                logging.info(f"{obj['id']} is a system defined read only object that happens to be unused. This will not be removed!")
+
+        bulk_delete = fmcapi.Networks(fmc=fmc)
+        bulk_delete.bulk = ids
+        bulk_delete.bulk_delete()
+    else:
+        logging.info(f'No unused objects to bulk delete')
+
     logging.info("Test ProtocolPort done.\n")


### PR DESCRIPTION
Finally got around to putting together something rudimentary to support bulk post and delete of network/port objects. 
There are other object types that support bulk operations. These _should_ work with this code as well, but I have only tested the main types of objects so far. 