### PR TITLE
Selective Device Deployments

### DIFF
--- a/unit_tests/deployment_requests.py
+++ b/unit_tests/deployment_requests.py
@@ -5,5 +5,20 @@ import fmcapi
 def test__deployment_requests(fmc):
     logging.info("Testing DeploymentRequests() class.")
     tmp = fmcapi.DeploymentRequests(fmc=fmc)
-    logging.info(tmp.post())
+    # Deployments default to force deploy all devices while ignoring all warnings
+
+    # Deploy all devices with pending deployments
+    resp = tmp.post()
+
+    # Deploy a specific selection of devices instead of all of them
+    # tmp.deploy_all = False
+    # tmp.deploy_device_names = ['device1', 'device2']
+    # resp = tmp.post()
+
+    # Deploy without force or without ignoring warnings
+    # tmp.forceDeploy = False
+    # tmp.ignoreWarning = False
+    # tmp.post()
+
+    logging.info(resp)
     logging.info("Testing DeploymentRequests() class done.\n")


### PR DESCRIPTION
Added the ability to provide a list of devices to deployment requests so that you are not forced to deploy all devices at once if you don't want to. 

Deployment options: Force and IgnoreWarnings are now configurable as well

This implementation still defaults to deploying all devices with force and ignore warnings as to not break existing library code references or existing user written code. 