### PR TITLE
Adding several missing possible kwargs for expanded device records

### DIFF
--- a/fmcapi/api_objects/device_services/devicerecords.py
+++ b/fmcapi/api_objects/device_services/devicerecords.py
@@ -51,8 +51,15 @@ class DeviceRecords(APIClassTemplate):
             "prohibitPacketTransfer",
             "keepLocalEvents",
             "ftdMode",
-            "keepLocalEvents",
             "expanded",
+            "deploymentStatus",
+            "healthMessage",
+            "advanced",
+            "analyticsOnly",
+            "metadata",
+            "snortEngine",
+            "isFWaaS",
+            "managementState",
         ]
     )
     URL_SUFFIX = "/devices/devicerecords"


### PR DESCRIPTION
Notably, metadata was included as a possible kwarg upon finding out that deployment api and upgrade api utilize different device names if a device is in HA or a cluster. Metadata from device records allows you to search the device name and derive if a device is in HA/Cluster and derive that HA/Cluster name. This HA/Cluster name is what is used in deployment request. 

These were based on an FMC running 7.6