### PR TITLE
fix for issue#211

### DIFF
--- a/fmcapi/api_objects/system_information/serverversion.py
+++ b/fmcapi/api_objects/system_information/serverversion.py
@@ -45,7 +45,7 @@ class ServerVersion(object):  # Can't import APIClassTemplate due to dependency 
             self.vdbVersion = response["items"][0]["vdbVersion"]
             self.sruVersion = response["items"][0]["sruVersion"]
             self.serverVersion = response["items"][0]["serverVersion"]
-            self.geoVersion = response["items"][0]["geoVersion"]
+            self.geoVersion = response["items"][0].get("geoVersion")
         return response
 
     def post(self):


### PR DESCRIPTION
This is a fix for #211 
It implements a safe get method for the geoVersion key to keep compatibility with FMC version <7.7 while allowing operations with FMC 7.7+ where this key is removed