### PR TITLE
fixed issue with autonatrules and InterfaceGroup

### DIFF
--- a/fmcapi/api_objects/policy_services/autonatrules.py
+++ b/fmcapi/api_objects/policy_services/autonatrules.py
@@ -152,22 +152,24 @@ class AutoNatRules(APIClassTemplate):
         new_intf = None
         for item in items:
             if item["name"] == name:
-                new_intf = {"id": item["id"], "type": item["type"]}
+                new_intf = item
                 break
         if new_intf is None:
             logging.warning(
                 f'Interface Object "{name}" is not found in FMC.  Cannot add to sourceInterface.'
             )
         else:
-            if new_intf["type"] == "InterfaceGroup" and len(new_intf.interfaces) > 1:
-                logging.warning(
-                    f'Interface Object "{name}" contains more than one physical interface. Cannot add to '
-                    f"sourceInterface."
-                )
-            else:
-                self.sourceInterface = new_intf
-                logging.info(f'Interface Object "{name}" added to NAT Policy.')
-
+            if new_intf["type"] == "InterfaceGroup":
+                if len(new_intf["interfaces"]) > 1:
+                    logging.warning(
+                        f'Interface Object "{name}" contains more than one physical interface. Cannot add to '
+                        f"sourceInterface."
+                    )
+                    return
+ 
+            self.sourceInterface = {"id": item["id"], "type": item["type"]}
+            logging.info(f'Interface Object "{name}" added to NAT Policy.')
+ 
     def destination_intf(self, name):
         """
         Associate interface to this rule.
@@ -181,21 +183,23 @@ class AutoNatRules(APIClassTemplate):
         new_intf = None
         for item in items:
             if item["name"] == name:
-                new_intf = {"id": item["id"], "type": item["type"]}
+                new_intf = item
                 break
         if new_intf is None:
             logging.warning(
                 f'Interface Object "{name}" is not found in FMC.  Cannot add to destinationInterface.'
             )
         else:
-            if new_intf["type"] == "InterfaceGroup" and len(new_intf.interfaces) > 1:
-                logging.warning(
-                    f'Interface Object "{name}" contains more than one physical interface. Cannot add to '
-                    f"destinationInterface."
-                )
-            else:
-                self.destinationInterface = new_intf
-                logging.info(f'Interface Object "{name}" added to NAT Policy.')
+            if new_intf["type"] == "InterfaceGroup":
+                if len(new_intf["interfaces"]) > 1:
+                    logging.warning(
+                        f'Interface Object "{name}" contains more than one physical interface. Cannot add to '
+                        f"destinationInterface."
+                    )
+                    return
+ 
+            self.destinationInterface = {"id": item["id"], "type": item["type"]}
+            logging.info(f'Interface Object "{name}" added to NAT Policy.')
 
     def identity_nat(self, name):
         """


### PR DESCRIPTION
Came across a bug with using interface groups in autonatrules. After finding the entry with the right name, it creates a dict of just the id and type. Later it tries to check the interfaces attr which doesn't exist.

Fixed by feeding the whole entry back to the check. I later break it down back to id and type.